### PR TITLE
refactor: Move all info hashes to singular Hash struct

### DIFF
--- a/lib/src/hashes.rs
+++ b/lib/src/hashes.rs
@@ -1,0 +1,189 @@
+use std::fmt::{self, Display};
+
+use serde::{
+   Deserialize, Deserializer, Serialize, Serializer,
+   de::{self, Visitor},
+};
+
+#[derive(Debug, Clone, Copy)]
+pub struct Hash<const N: usize>([u8; N]);
+
+pub type InfoHash = Hash<20>;
+
+impl<const N: usize> Hash<N> {
+   pub fn new(bytes: [u8; N]) -> Self {
+      Hash(bytes)
+   }
+
+   pub fn as_bytes(&self) -> &[u8; N] {
+      &self.0
+   }
+   pub fn to_hex(&self) -> String {
+      hex::encode(self.0)
+   }
+   pub fn from_hex(hex: impl AsRef<[u8]>) -> Result<Self, hex::FromHexError> {
+      let bytes = hex::decode(hex)?;
+      if bytes.len() == N {
+         Ok(Hash(bytes.try_into().unwrap()))
+      } else {
+         Err(hex::FromHexError::InvalidStringLength)
+      }
+   }
+}
+
+/// Auto turns the hash into a hexadecimal string when displayed in a string context
+impl<const N: usize> Display for Hash<N> {
+   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+      write!(f, "{}", self.to_hex())
+   }
+}
+
+impl<'de, const N: usize> Deserialize<'de> for Hash<N> {
+   fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+   where
+      D: Deserializer<'de>,
+   {
+      deserializer.deserialize_bytes(HashVisitor::<N>)
+   }
+}
+
+impl<const N: usize> Serialize for Hash<N> {
+   fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+   where
+      S: Serializer,
+   {
+      serializer.serialize_bytes(&self.0)
+   }
+}
+
+struct HashVisitor<const N: usize>;
+
+impl<const N: usize> Visitor<'_> for HashVisitor<N> {
+   type Value = Hash<N>;
+
+   fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+      formatter.write_str(&format!("a byte string whose length is  {}", N))
+   }
+
+   fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+   where
+      E: de::Error,
+   {
+      if v.len() == N {
+         Ok(Hash(v.try_into().unwrap()))
+      } else {
+         Err(E::custom(format!(
+            "Expect length is {}, found {}",
+            N,
+            v.len(),
+         )))
+      }
+   }
+}
+/// A vector of [Hashes](Hash) of the same length
+#[derive(Debug)]
+pub struct HashVec<const N: usize>(Vec<Hash<N>>);
+
+impl<const N: usize> Default for HashVec<N> {
+   fn default() -> Self {
+      Self::new()
+   }
+}
+
+impl<const N: usize> HashVec<N> {
+   pub fn new() -> Self {
+      HashVec(Vec::new())
+   }
+
+   pub fn push(&mut self, hash: Hash<N>) {
+      self.0.push(hash);
+   }
+
+   pub fn len(&self) -> usize {
+      self.0.len()
+   }
+
+   pub fn is_empty(&self) -> bool {
+      self.0.is_empty()
+   }
+
+   /// Flatten the vector of hashes into a single vector of bytes.
+   /// # Example
+   /// ```
+   /// let hashes = HashVec::new();
+   /// hashes.push(Hash([0, 0, 0]));
+   /// hashes.push(Hash([1, 1, 2]));
+   /// let flattened = hashes.flatten();
+   /// assert_eq!(flattened, vec![0, 0, 0, 1, 1, 2]);
+   /// ```
+   pub fn flatten(&self) -> Vec<u8> {
+      let mut result = Vec::with_capacity(N * self.len());
+      for hash in &self.0 {
+         result.extend_from_slice(&hash.0);
+      }
+      result
+   }
+}
+
+impl<const N: usize> IntoIterator for HashVec<N> {
+   type Item = Hash<N>;
+   type IntoIter = std::vec::IntoIter<Self::Item>;
+
+   fn into_iter(self) -> Self::IntoIter {
+      self.0.into_iter()
+   }
+}
+
+struct HashVecVisitor<const N: usize>;
+impl<const N: usize> HashVecVisitor<N> {
+   pub fn new() -> Self {
+      HashVecVisitor
+   }
+}
+
+impl<const N: usize> Visitor<'_> for HashVecVisitor<N> {
+   type Value = HashVec<N>;
+
+   fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+      formatter.write_str(&format!(
+         "a byte string whose length is a multiple of {}",
+         N
+      ))
+   }
+
+   fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+   where
+      E: de::Error,
+   {
+      if v.len() % N != 0 {
+         return Err(E::custom(format!("length is {}", v.len())));
+      }
+      let mut vec = Vec::with_capacity(v.len() / N);
+      for chunk in v.chunks(N) {
+         vec.push(Hash(
+            chunk
+               .try_into()
+               .unwrap_or_else(|_| panic!("guaranteed to be length {N}")),
+         ));
+      }
+      Ok(HashVec(vec))
+   }
+}
+
+impl<const N: usize> Serialize for HashVec<N> {
+   fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+   where
+      S: Serializer,
+   {
+      serializer.serialize_bytes(&self.flatten())
+   }
+}
+
+impl<'de, const N: usize> Deserialize<'de> for HashVec<N> {
+   fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+   where
+      D: Deserializer<'de>,
+   {
+      deserializer.deserialize_bytes(HashVecVisitor::new())
+   }
+}

--- a/lib/src/hashes.rs
+++ b/lib/src/hashes.rs
@@ -5,26 +5,112 @@ use serde::{
    de::{self, Visitor},
 };
 
+/// A fixed-length byte array that can represent various hash values or identifiers.
+///
+/// `Hash<N>` is a generic wrapper around a byte array of length `N` that provides
+/// convenient methods for conversion between different representations.
+///
+/// # Examples
+///
+/// ```
+/// use tortillas::hashes::Hash;
+///
+/// // Create a hash from a byte array
+/// let hash = Hash::new([0; 5]);
+/// assert_eq!(hash.to_hex(), "0000000000");
+///
+/// // Create a hash from a hex string
+/// let from_hex = Hash::<5>::from_hex("0102030405").unwrap();
+/// assert_eq!(from_hex.as_bytes(), &[1, 2, 3, 4, 5]);
+///
+/// // Display a hash (automatically converts to hex)
+/// println!("Hash: {}", hash); // Outputs: Hash: 0000000000
+/// ```
 #[derive(Debug, Clone, Copy)]
 pub struct Hash<const N: usize>([u8; N]);
 
+/// A specialized Hash type for BitTorrent info hashes (20 bytes/160 bits)
 pub type InfoHash = Hash<20>;
 
 impl<const N: usize> Hash<N> {
+   /// Creates a new Hash from a byte array of length N.
+   ///
+   /// # Examples
+   ///
+   /// ```
+   /// use tortillas::hashes::Hash;
+   ///
+   /// let hash = Hash::new([1, 2, 3, 4, 5]);
+   /// ```
    pub fn new(bytes: [u8; N]) -> Self {
       Hash(bytes)
    }
 
+   /// Creates a new Hash from a byte array of length N.
+   /// This is an alias for `new()` with a more descriptive name.
+   ///
+   /// # Examples
+   ///
+   /// ```
+   /// use tortillas::hashes::Hash;
+   ///
+   /// let hash = Hash::from_bytes([1, 2, 3, 4, 5]);
+   /// ```
    pub fn from_bytes(bytes: [u8; N]) -> Self {
       Hash(bytes)
    }
 
+   /// Returns a reference to the underlying byte array.
+   ///
+   /// # Examples
+   ///
+   /// ```
+   /// use tortillas::hashes::Hash;
+   ///
+   /// let hash = Hash::new([1, 2, 3, 4, 5]);
+   /// assert_eq!(hash.as_bytes(), &[1, 2, 3, 4, 5]);
+   /// ```
    pub fn as_bytes(&self) -> &[u8; N] {
       &self.0
    }
+
+   /// Converts the hash to a hexadecimal string representation.
+   ///
+   /// # Examples
+   ///
+   /// ```
+   /// use tortillas::hashes::Hash;
+   ///
+   /// let hash = Hash::new([0x12, 0x34, 0x56]);
+   /// assert_eq!(hash.to_hex(), "123456");
+   /// ```
    pub fn to_hex(&self) -> String {
       hex::encode(self.0)
    }
+
+   /// Creates a Hash from a hexadecimal string.
+   ///
+   /// The input string must have exactly 2*N characters (2 hex chars per byte).
+   ///
+   /// # Errors
+   ///
+   /// Returns an error if the hex string is invalid or has incorrect length.
+   ///
+   /// # Examples
+   ///
+   /// ```
+   /// use tortillas::hashes::Hash;
+   ///
+   /// let hash = Hash::<3>::from_hex("123456").unwrap();
+   /// assert_eq!(hash.as_bytes(), &[0x12, 0x34, 0x56]);
+   ///
+   /// // Invalid length
+   /// assert!(Hash::<3>::from_hex("12345").is_err());
+   /// assert!(Hash::<3>::from_hex("1234567").is_err());
+   ///
+   /// // Invalid hex characters
+   /// assert!(Hash::<3>::from_hex("12345G").is_err());
+   /// ```
    pub fn from_hex(hex: impl AsRef<[u8]>) -> Result<Self, hex::FromHexError> {
       let bytes = hex::decode(hex)?;
       if bytes.len() == N {
@@ -35,7 +121,20 @@ impl<const N: usize> Hash<N> {
    }
 }
 
-/// Auto turns the hash into a hexadecimal string when displayed in a string context
+/// Implements the Display trait for Hash, converting it to a hexadecimal string.
+///
+/// This allows a Hash to be directly used in string formatting contexts.
+///
+/// # Examples
+///
+/// ```
+/// use tortillas::hashes::Hash;
+///
+/// let hash = Hash::new([0x12, 0x34, 0x56]);
+/// println!("Hash: {}", hash); // Outputs: Hash: 123456
+/// let formatted = format!("Hash value: {}", hash);
+/// assert_eq!(formatted, "Hash value: 123456");
+/// ```
 impl<const N: usize> Display for Hash<N> {
    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
       write!(f, "{}", self.to_hex())
@@ -66,7 +165,7 @@ impl<const N: usize> Visitor<'_> for HashVisitor<N> {
    type Value = Hash<N>;
 
    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-      formatter.write_str(&format!("a byte string whose length is  {}", N))
+      formatter.write_str(&format!("a byte string whose length is {}", N))
    }
 
    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
@@ -77,14 +176,41 @@ impl<const N: usize> Visitor<'_> for HashVisitor<N> {
          Ok(Hash(v.try_into().unwrap()))
       } else {
          Err(E::custom(format!(
-            "Expect length is {}, found {}",
+            "Expected length is {}, found {}",
             N,
             v.len(),
          )))
       }
    }
 }
-/// A vector of [Hashes](Hash) of the same length
+
+/// A collection of Hash<N> values that provides efficient storage and operations.
+///
+/// HashVec is optimized for working with multiple hashes of the same length,
+/// providing methods to manipulate them as a collection and serialize/deserialize
+/// them efficiently.
+///
+/// # Examples
+///
+/// ```
+/// use tortillas::hashes::{Hash, HashVec};
+///
+/// // Create a new empty collection
+/// let mut hashes: HashVec<4> = HashVec::new();
+///
+/// // Add some hashes
+/// hashes.push(Hash::new([1, 2, 3, 4]));
+/// hashes.push(Hash::new([5, 6, 7, 8]));
+///
+/// // Check properties
+/// assert_eq!(hashes.len(), 2);
+/// assert!(!hashes.is_empty());
+///
+/// // Iterate over hashes
+/// for hash in hashes {
+///     println!("Hash: {}", hash);
+/// }
+/// ```
 #[derive(Debug)]
 pub struct HashVec<const N: usize>(Vec<Hash<N>>);
 
@@ -95,30 +221,86 @@ impl<const N: usize> Default for HashVec<N> {
 }
 
 impl<const N: usize> HashVec<N> {
+   /// Creates a new empty HashVec.
+   ///
+   /// # Examples
+   ///
+   /// ```
+   /// use tortillas::hashes::HashVec;
+   ///
+   /// let hashes: HashVec<20> = HashVec::new();
+   /// assert!(hashes.is_empty());
+   /// ```
    pub fn new() -> Self {
       HashVec(Vec::new())
    }
 
+   /// Adds a hash to the collection.
+   ///
+   /// # Examples
+   ///
+   /// ```
+   /// use tortillas::hashes::{Hash, HashVec};
+   ///
+   /// let mut hashes = HashVec::new();
+   /// hashes.push(Hash::new([1, 2, 3]));
+   /// assert_eq!(hashes.len(), 1);
+   /// ```
    pub fn push(&mut self, hash: Hash<N>) {
       self.0.push(hash);
    }
 
+   /// Returns the number of hashes in the collection.
+   ///
+   /// # Examples
+   ///
+   /// ```
+   /// use tortillas::hashes::{Hash, HashVec};
+   ///
+   /// let mut hashes = HashVec::new();
+   /// assert_eq!(hashes.len(), 0);
+   ///
+   /// hashes.push(Hash::new([1, 2, 3]));
+   /// hashes.push(Hash::new([4, 5, 6]));
+   /// assert_eq!(hashes.len(), 2);
+   /// ```
    pub fn len(&self) -> usize {
       self.0.len()
    }
 
+   /// Returns true if the collection contains no hashes.
+   ///
+   /// # Examples
+   ///
+   /// ```
+   /// use tortillas::hashes::{Hash, HashVec};
+   ///
+   /// let mut hashes = HashVec::new();
+   /// assert!(hashes.is_empty());
+   ///
+   /// hashes.push(Hash::new([1, 2, 3]));
+   /// assert!(!hashes.is_empty());
+   /// ```
    pub fn is_empty(&self) -> bool {
       self.0.is_empty()
    }
 
-   /// Flatten the vector of hashes into a single vector of bytes.
-   /// # Example
+   /// Flattens the vector of hashes into a single vector of bytes.
+   ///
+   /// This is useful for serialization or when you need to work with
+   /// the raw bytes of all hashes concatenated together.
+   ///
+   /// # Examples
+   ///
    /// ```
-   /// let hashes = HashVec::new();
-   /// hashes.push(Hash([0, 0, 0]));
-   /// hashes.push(Hash([1, 1, 2]));
+   /// use tortillas::hashes::{Hash, HashVec};
+   ///
+   /// let mut hashes = HashVec::new();
+   /// hashes.push(Hash::new([0, 1, 2]));
+   /// hashes.push(Hash::new([3, 4, 5]));
+   ///
    /// let flattened = hashes.flatten();
-   /// assert_eq!(flattened, vec![0, 0, 0, 1, 1, 2]);
+   /// assert_eq!(flattened, vec![0, 1, 2, 3, 4, 5]);
    /// ```
    pub fn flatten(&self) -> Vec<u8> {
       let mut result = Vec::with_capacity(N * self.len());
@@ -129,6 +311,24 @@ impl<const N: usize> HashVec<N> {
    }
 }
 
+/// Implements IntoIterator for HashVec to allow iteration over contained hashes.
+///
+/// # Examples
+///
+/// ```
+/// use tortillas::hashes::{Hash, HashVec};
+///
+/// let mut hashes = HashVec::new();
+/// hashes.push(Hash::new([1, 2, 3]));
+/// hashes.push(Hash::new([4, 5, 6]));
+///
+/// let mut sum = 0;
+/// for hash in hashes {
+///     // Do something with each hash
+///     sum += hash.as_bytes().iter().sum::<u8>() as u32;
+/// }
+/// assert_eq!(sum, 21); // 1+2+3 + 4+5+6 = 21
+/// ```
 impl<const N: usize> IntoIterator for HashVec<N> {
    type Item = Hash<N>;
    type IntoIter = std::vec::IntoIter<Self::Item>;
@@ -139,7 +339,9 @@ impl<const N: usize> IntoIterator for HashVec<N> {
 }
 
 struct HashVecVisitor<const N: usize>;
+
 impl<const N: usize> HashVecVisitor<N> {
+   /// Creates a new HashVecVisitor.
    pub fn new() -> Self {
       HashVecVisitor
    }
@@ -160,8 +362,13 @@ impl<const N: usize> Visitor<'_> for HashVecVisitor<N> {
       E: de::Error,
    {
       if v.len() % N != 0 {
-         return Err(E::custom(format!("length is {}", v.len())));
+         return Err(E::custom(format!(
+            "Expected length to be a multiple of {}, found {}",
+            N,
+            v.len()
+         )));
       }
+
       let mut vec = Vec::with_capacity(v.len() / N);
       for chunk in v.chunks(N) {
          vec.push(Hash(
@@ -183,6 +390,8 @@ impl<const N: usize> Serialize for HashVec<N> {
    }
 }
 
+/// This deserializes a flat byte array into a HashVec, splitting it into
+/// individual hashes of length N.
 impl<'de, const N: usize> Deserialize<'de> for HashVec<N> {
    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
    where

--- a/lib/src/hashes.rs
+++ b/lib/src/hashes.rs
@@ -13,7 +13,7 @@ use serde::{
 /// # Examples
 ///
 /// ```
-/// use tortillas::hashes::Hash;
+/// use libtortillas::hashes::Hash;
 ///
 /// // Create a hash from a byte array
 /// let hash = Hash::new([0; 5]);
@@ -38,7 +38,7 @@ impl<const N: usize> Hash<N> {
    /// # Examples
    ///
    /// ```
-   /// use tortillas::hashes::Hash;
+   /// use libtortillas::hashes::Hash;
    ///
    /// let hash = Hash::new([1, 2, 3, 4, 5]);
    /// ```
@@ -52,7 +52,7 @@ impl<const N: usize> Hash<N> {
    /// # Examples
    ///
    /// ```
-   /// use tortillas::hashes::Hash;
+   /// use libtortillas::hashes::Hash;
    ///
    /// let hash = Hash::from_bytes([1, 2, 3, 4, 5]);
    /// ```
@@ -65,7 +65,7 @@ impl<const N: usize> Hash<N> {
    /// # Examples
    ///
    /// ```
-   /// use tortillas::hashes::Hash;
+   /// use libtortillas::hashes::Hash;
    ///
    /// let hash = Hash::new([1, 2, 3, 4, 5]);
    /// assert_eq!(hash.as_bytes(), &[1, 2, 3, 4, 5]);
@@ -79,7 +79,7 @@ impl<const N: usize> Hash<N> {
    /// # Examples
    ///
    /// ```
-   /// use tortillas::hashes::Hash;
+   /// use libtortillas::hashes::Hash;
    ///
    /// let hash = Hash::new([0x12, 0x34, 0x56]);
    /// assert_eq!(hash.to_hex(), "123456");
@@ -99,7 +99,7 @@ impl<const N: usize> Hash<N> {
    /// # Examples
    ///
    /// ```
-   /// use tortillas::hashes::Hash;
+   /// use libtortillas::hashes::Hash;
    ///
    /// let hash = Hash::<3>::from_hex("123456").unwrap();
    /// assert_eq!(hash.as_bytes(), &[0x12, 0x34, 0x56]);
@@ -128,7 +128,7 @@ impl<const N: usize> Hash<N> {
 /// # Examples
 ///
 /// ```
-/// use tortillas::hashes::Hash;
+/// use libtortillas::hashes::Hash;
 ///
 /// let hash = Hash::new([0x12, 0x34, 0x56]);
 /// println!("Hash: {}", hash); // Outputs: Hash: 123456
@@ -193,7 +193,7 @@ impl<const N: usize> Visitor<'_> for HashVisitor<N> {
 /// # Examples
 ///
 /// ```
-/// use tortillas::hashes::{Hash, HashVec};
+/// use libtortillas::hashes::{Hash, HashVec};
 ///
 /// // Create a new empty collection
 /// let mut hashes: HashVec<4> = HashVec::new();
@@ -226,7 +226,7 @@ impl<const N: usize> HashVec<N> {
    /// # Examples
    ///
    /// ```
-   /// use tortillas::hashes::HashVec;
+   /// use libtortillas::hashes::HashVec;
    ///
    /// let hashes: HashVec<20> = HashVec::new();
    /// assert!(hashes.is_empty());
@@ -240,7 +240,7 @@ impl<const N: usize> HashVec<N> {
    /// # Examples
    ///
    /// ```
-   /// use tortillas::hashes::{Hash, HashVec};
+   /// use libtortillas::hashes::{Hash, HashVec};
    ///
    /// let mut hashes = HashVec::new();
    /// hashes.push(Hash::new([1, 2, 3]));
@@ -255,7 +255,7 @@ impl<const N: usize> HashVec<N> {
    /// # Examples
    ///
    /// ```
-   /// use tortillas::hashes::{Hash, HashVec};
+   /// use libtortillas::hashes::{Hash, HashVec};
    ///
    /// let mut hashes = HashVec::new();
    /// assert_eq!(hashes.len(), 0);
@@ -273,7 +273,7 @@ impl<const N: usize> HashVec<N> {
    /// # Examples
    ///
    /// ```
-   /// use tortillas::hashes::{Hash, HashVec};
+   /// use libtortillas::hashes::{Hash, HashVec};
    ///
    /// let mut hashes = HashVec::new();
    /// assert!(hashes.is_empty());
@@ -293,7 +293,7 @@ impl<const N: usize> HashVec<N> {
    /// # Examples
    ///
    /// ```
-   /// use tortillas::hashes::{Hash, HashVec};
+   /// use libtortillas::hashes::{Hash, HashVec};
    ///
    /// let mut hashes = HashVec::new();
    /// hashes.push(Hash::new([0, 1, 2]));
@@ -316,7 +316,7 @@ impl<const N: usize> HashVec<N> {
 /// # Examples
 ///
 /// ```
-/// use tortillas::hashes::{Hash, HashVec};
+/// use libtortillas::hashes::{Hash, HashVec};
 ///
 /// let mut hashes = HashVec::new();
 /// hashes.push(Hash::new([1, 2, 3]));

--- a/lib/src/hashes.rs
+++ b/lib/src/hashes.rs
@@ -15,6 +15,10 @@ impl<const N: usize> Hash<N> {
       Hash(bytes)
    }
 
+   pub fn from_bytes(bytes: [u8; N]) -> Self {
+      Hash(bytes)
+   }
+
    pub fn as_bytes(&self) -> &[u8; N] {
       &self.0
    }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod errors;
+pub mod hashes;
 pub mod parser;
 pub mod tracker;

--- a/lib/src/parser/file.rs
+++ b/lib/src/parser/file.rs
@@ -1,13 +1,14 @@
-use crate::{parser::MetaInfo, tracker::Tracker};
+use crate::{
+   hashes::{Hash, HashVec, InfoHash},
+   parser::MetaInfo,
+   tracker::Tracker,
+};
 
 use anyhow::Result;
-use serde::{
-   Deserialize, Serialize, Serializer,
-   de::{self, Visitor},
-};
+use serde::{Deserialize, Serialize};
 use serde_bencode as bencode;
 use sha1::{Digest, Sha1};
-use std::{fmt, path::PathBuf};
+use std::path::PathBuf;
 
 use tokio::fs;
 
@@ -44,7 +45,7 @@ pub struct Info {
    #[serde(rename = "piece length")]
    piece_length: u64,
    /// Binary string of concatenated 20-byte SHA-1 hash values
-   pieces: Hashes,
+   pieces: HashVec<20>,
    #[serde(flatten)]
    file: InfoKeys,
 
@@ -75,62 +76,11 @@ pub struct InfoFile {
 
 impl Info {
    /// Gets the file hash (xt, or exact topic) for the given Info struct
-   pub fn hash(&self) -> Result<String> {
+   pub fn hash(&self) -> Result<InfoHash> {
       let mut hasher = Sha1::new();
       hasher.update(serde_bencode::to_bytes(&self)?);
       let result = hasher.finalize();
-      Ok(hex::encode(result))
-   }
-}
-
-/// A custom type for serializing and deserializing a vector of 20-byte SHA-1 hashes.
-/// Credit to [Jon Gjengset](https://github.com/jonhoo/codecrafters-bittorrent-rust/)
-#[derive(Debug)]
-pub struct Hashes(pub Vec<[u8; 20]>);
-
-// Add this implementation
-impl<'de> Deserialize<'de> for Hashes {
-   fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-   where
-      D: de::Deserializer<'de>,
-   {
-      deserializer.deserialize_bytes(HashesVisitor)
-   }
-}
-
-impl Serialize for Hashes {
-   fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-   where
-      S: Serializer,
-   {
-      let single_slice = self.0.concat();
-
-      serializer.serialize_bytes(&single_slice)
-   }
-}
-
-struct HashesVisitor;
-
-impl Visitor<'_> for HashesVisitor {
-   type Value = Hashes;
-
-   fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-      formatter.write_str("a byte string whose length is a multiple of 20")
-   }
-
-   fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-   where
-      E: de::Error,
-   {
-      if v.len() % 20 != 0 {
-         return Err(E::custom(format!("length is {}", v.len())));
-      }
-
-      Ok(Hashes(
-         v.chunks(20)
-            .map(|slice_20| slice_20.try_into().expect("guaranteed to be length 20"))
-            .collect(),
-      ))
+      Ok(Hash::from_hex(hex::encode(result))?)
    }
 }
 

--- a/lib/src/parser/magnet.rs
+++ b/lib/src/parser/magnet.rs
@@ -87,8 +87,15 @@ impl MagnetUri {
       // Parse the modified query string
       Ok(MetaInfo::MagnetUri(serde_qs::from_str(&final_qs)?))
    }
-   pub fn info_hash(&self) -> InfoHash {
-      Hash::from_hex(self.info_hash.split(":").last().unwrap()).unwrap()
+   pub fn info_hash(&self) -> Result<InfoHash, anyhow::Error> {
+      let hex_part = self
+         .info_hash
+         .split(":")
+         .last()
+         .ok_or_else(|| anyhow::anyhow!("Invalid info_hash format: no colon found"))?;
+
+      Hash::from_hex(hex_part)
+         .map_err(|e| anyhow::anyhow!("Failed to parse info_hash from hex: {}", e))
    }
 }
 

--- a/lib/src/parser/magnet.rs
+++ b/lib/src/parser/magnet.rs
@@ -1,6 +1,10 @@
 use std::collections::HashMap;
 
-use crate::{parser::MetaInfo, tracker::Tracker};
+use crate::{
+   hashes::{Hash, InfoHash},
+   parser::MetaInfo,
+   tracker::Tracker,
+};
 
 use anyhow::Result;
 use serde::Deserialize;
@@ -9,8 +13,9 @@ use serde_qs;
 /// Magnet URI Spec: https://en.wikipedia.org/wiki/Magnet_URI_scheme or https://www.bittorrent.org/beps/bep_0053.html
 #[derive(Debug, Deserialize)]
 pub struct MagnetUri {
+   /// use `Self::info_hash` to get the info hash as a `Hash` struct.
    #[serde(rename(deserialize = "xt"))]
-   pub info_hash: String,
+   info_hash: String,
 
    #[serde(rename(deserialize = "dn"))]
    pub name: String,
@@ -81,6 +86,9 @@ impl MagnetUri {
 
       // Parse the modified query string
       Ok(MetaInfo::MagnetUri(serde_qs::from_str(&final_qs)?))
+   }
+   pub fn info_hash(&self) -> InfoHash {
+      Hash::from_hex(self.info_hash.split(":").last().unwrap()).unwrap()
    }
 }
 

--- a/lib/src/tracker/http.rs
+++ b/lib/src/tracker/http.rs
@@ -231,7 +231,7 @@ mod tests {
             let info_hash = magnet.info_hash();
             let announce_list = magnet.announce_list.unwrap();
             let announce_uri = announce_list[0].uri();
-            let mut http_tracker = HttpTracker::new(announce_uri, info_hash);
+            let mut http_tracker = HttpTracker::new(announce_uri, info_hash.unwrap());
 
             // Make request
             let res = HttpTracker::stream_peers(&mut http_tracker)

--- a/lib/src/tracker/http.rs
+++ b/lib/src/tracker/http.rs
@@ -1,5 +1,8 @@
 use super::{PeerAddr, TrackerTrait};
-use crate::errors::{HttpTrackerError, TrackerError};
+use crate::{
+   errors::{HttpTrackerError, TrackerError},
+   hashes::InfoHash,
+};
 use rand::distr::{Alphanumeric, SampleString};
 use serde::{
    Deserialize, Serialize,
@@ -55,13 +58,13 @@ impl TrackerRequest {
 pub struct HttpTracker {
    uri: String,
    peer_id: String,
-   info_hash: String,
+   info_hash: InfoHash,
    params: TrackerRequest,
 }
 
 impl HttpTracker {
    #[instrument(skip(info_hash), fields(uri = %uri))]
-   pub fn new(uri: String, info_hash: String) -> HttpTracker {
+   pub fn new(uri: String, info_hash: InfoHash) -> HttpTracker {
       let peer_id = Alphanumeric.sample_string(&mut rand::rng(), 20);
       debug!(peer_id = %peer_id, "Generated peer ID");
 
@@ -93,19 +96,6 @@ impl TrackerTrait for HttpTracker {
    async fn stream_peers(&mut self) -> anyhow::Result<Vec<PeerAddr>> {
       // Decode info_hash
       debug!("Decoding info hash");
-      let info_hash_part = self.info_hash.split("urn:btih:").last().ok_or_else(|| {
-         HttpTrackerError::InvalidInfoHash(format!("Invalid info_hash format: {}", self.info_hash))
-      })?;
-
-      let decoded_hash = hex::decode(info_hash_part).map_err(|e| {
-         error!(error = %e, "Failed to decode info_hash");
-         HttpTrackerError::InvalidInfoHash(format!("Failed to decode info_hash: {}", e))
-      })?;
-
-      let info_hash: [u8; 20] = decoded_hash.try_into().map_err(|_| {
-         error!("Info hash has incorrect length");
-         HttpTrackerError::InvalidInfoHash("Info hash must be 20 bytes".to_string())
-      })?;
 
       // Generate params + URL. Specifically using the compact format by adding "compact=1" to
       // params.
@@ -113,7 +103,7 @@ impl TrackerTrait for HttpTracker {
       let params = serde_qs::to_string(&self.params)
          .map_err(|e| HttpTrackerError::ParameterEncoding(e.to_string()))?;
 
-      let info_hash_encoded = urlencode(&info_hash);
+      let info_hash_encoded = urlencode(self.info_hash.as_bytes());
       trace!(encoded_hash = %info_hash_encoded, "URL-encoded info hash");
 
       let uri_params = format!(
@@ -238,9 +228,9 @@ mod tests {
       let metainfo = MagnetUri::parse(contents).await.unwrap();
       match metainfo {
          MetaInfo::MagnetUri(magnet) => {
+            let info_hash = magnet.info_hash();
             let announce_list = magnet.announce_list.unwrap();
             let announce_uri = announce_list[0].uri();
-            let info_hash = magnet.info_hash;
             let mut http_tracker = HttpTracker::new(announce_uri, info_hash);
 
             // Make request

--- a/lib/src/tracker/mod.rs
+++ b/lib/src/tracker/mod.rs
@@ -64,18 +64,18 @@ impl Tracker {
    }
 }
 
-struct AnnounceUriVisitor;
+struct TrackerVisitor;
 
 impl<'de> Deserialize<'de> for Tracker {
    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
    where
       D: serde::Deserializer<'de>,
    {
-      deserializer.deserialize_string(AnnounceUriVisitor)
+      deserializer.deserialize_string(TrackerVisitor)
    }
 }
 
-impl Visitor<'_> for AnnounceUriVisitor {
+impl Visitor<'_> for TrackerVisitor {
    type Value = Tracker;
 
    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/lib/src/tracker/mod.rs
+++ b/lib/src/tracker/mod.rs
@@ -6,6 +6,8 @@ use serde::{
 };
 use std::{fmt, net::Ipv4Addr};
 use udp::UdpTracker;
+
+use crate::hashes::InfoHash;
 pub mod http;
 pub mod udp;
 // mod websocket;
@@ -37,7 +39,7 @@ pub enum Tracker {
 }
 
 impl Tracker {
-   pub async fn get_peers(&self, info_hash: String) -> Result<Vec<PeerAddr>> {
+   pub async fn get_peers(&self, info_hash: InfoHash) -> Result<Vec<PeerAddr>> {
       match self {
          Tracker::Http(uri) => {
             let mut tracker = HttpTracker::new(uri.clone(), info_hash);
@@ -45,13 +47,7 @@ impl Tracker {
             Ok(tracker.stream_peers().await.unwrap())
          }
          Tracker::Udp(uri) => {
-            let mut tracker = UdpTracker::new(
-               uri.clone(),
-               None,
-               hex::decode(info_hash).unwrap().try_into().unwrap(),
-            )
-            .await
-            .unwrap();
+            let mut tracker = UdpTracker::new(uri.clone(), None, info_hash).await.unwrap();
 
             Ok(tracker.stream_peers().await.unwrap())
          }

--- a/lib/src/tracker/udp.rs
+++ b/lib/src/tracker/udp.rs
@@ -589,7 +589,7 @@ mod tests {
             let announce_list = magnet.announce_list.unwrap();
             let announce_url = announce_list[0].uri();
 
-            let mut udp_tracker = UdpTracker::new(announce_url, None, info_hash)
+            let mut udp_tracker = UdpTracker::new(announce_url, None, info_hash.unwrap())
                .await
                .unwrap();
             let stream = udp_tracker.stream_peers().await.unwrap();


### PR DESCRIPTION
#26 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced support for fixed-length hash management, enabling reliable conversion between hexadecimal strings and byte arrays, along with dedicated handling for torrent info hashes.
  
- **Refactor**
  - Streamlined the processing of hash values across metadata parsing, magnet link handling, and tracker integrations by replacing legacy conversion mechanisms with strongly typed structures, resulting in improved consistency and type safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->