### PR TITLE
fix: Use option for is_private field 

### DIFF
--- a/crates/libtortillas/src/parser/file.rs
+++ b/crates/libtortillas/src/parser/file.rs
@@ -72,9 +72,12 @@ pub struct Info {
    /// means private and 0 means public (or missing field).
    ///
    /// From <https://wiki.theory.org/BitTorrentSpecification#Info_Dictionary>
-   #[serde(rename = "private", default)]
-   #[serde_as(as = "BoolFromInt")]
-   is_private: bool,
+   ///
+   /// Needs to be an option because it's optional in the spec, see #62 for more
+   /// info
+   #[serde(rename = "private")]
+   #[serde_as(as = "Option<BoolFromInt>")]
+   is_private: Option<bool>,
 
    /// This is undocumented, AFAIK
    publisher: Option<String>,


### PR DESCRIPTION
#62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated comments to clarify that the "private" field is optional and referenced relevant issue for context.

* **Refactor**
  * Improved handling of the "private" field to better reflect its optional status in the BitTorrent specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->