### PR TITLE
refactor: Changed visiblity of Torrent and related funcs

### DIFF
--- a/crates/libtortillas/src/torrent/mod.rs
+++ b/crates/libtortillas/src/torrent/mod.rs
@@ -25,7 +25,7 @@ use crate::{
    tracker::{Tracker, TrackerActor, udp::UdpServer},
 };
 
-pub(crate) struct Torrent {
+pub struct Torrent {
    peers: Arc<DashMap<PeerId, ActorRef<PeerActor>>>,
    trackers: Arc<DashMap<Tracker, ActorRef<TrackerActor>>>,
 
@@ -54,7 +54,7 @@ impl fmt::Display for Torrent {
 }
 
 impl Torrent {
-   fn info_dict(&self) -> Option<&Info> {
+   pub fn info_dict(&self) -> Option<&Info> {
       if let Some(info) = &self.info {
          Some(info)
       } else {
@@ -65,7 +65,7 @@ impl Torrent {
       }
    }
 
-   fn info_hash(&self) -> InfoHash {
+   pub fn info_hash(&self) -> InfoHash {
       if let Some(info) = &self.info_dict() {
          info.hash().expect("Failed to compute info hash")
       } else {


### PR DESCRIPTION
Single commit PR -- see #104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The torrent type is now exposed in the public API.
  * Clients can retrieve a torrent’s metadata/details via a public accessor.
  * Clients can obtain a torrent’s info hash directly through the public API.
  * Enables easier integration and inspection of torrent data from outside the library.
  * Additive change with no breaking behavior for existing users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->