### PR TITLE
feat:  Implement `add_torrent`

### DIFF
--- a/crates/libtortillas/src/engine/mod.rs
+++ b/crates/libtortillas/src/engine/mod.rs
@@ -41,8 +41,8 @@ actor_request_response!(
 );
 
 /// The "top level" struct for torrenting. Handles all
-/// [Torrent](crate::torrent::Torrent) actors. Note that the engine itself also
-/// implements the [Actor](kameo::Actor) trait, and consequently behaves like an
+/// [Torrent] actors. Note that the engine itself also
+/// implements the [Actor] trait, and consequently behaves like an
 /// actor.
 pub struct Engine {
    /// Listener to wait for incoming TCP connections from peers
@@ -92,8 +92,9 @@ impl Engine {
    /// #[tokio::main]
    /// async fn main() {
    ///    let mut engine = Engine::new(todo!());
+   ///    let torrent_link = "https://example.com/example.torrent";
    ///    let torrent_key = engine
-   ///       .add_torrent("https://mydomain.com/video.torrent")
+   ///       .add_torrent(torrent_link)
    ///       .await
    ///       .expect("Failed to add torrent");
    ///
@@ -107,9 +108,10 @@ impl Engine {
    ///
    /// #[tokio::main]
    /// async fn main() {
-   ///    let mut engine = Engine::new(todo!);
+   ///    let mut engine = Engine::new(todo!());
    ///    let magnet_uri = "magnet:?xt=?????";
-   ///    let torrent_key = engine.add_torrent(magnet_uri)
+   ///    let torrent_key = engine
+   ///       .add_torrent(magnet_uri)
    ///       .await
    ///       .expect("Failed to add torrent");
    ///

--- a/crates/libtortillas/src/engine/mod.rs
+++ b/crates/libtortillas/src/engine/mod.rs
@@ -69,6 +69,13 @@ pub struct Engine {
 }
 
 impl Engine {
+   /// Starts the torrenting process for a given torrent. The spawned [Torrent
+   /// Actor](Torrent) will be controlled by the [Engine]
+   ///
+   /// This function accepts the following as input:
+   /// - A remote URL to a torrent file over HTTP/HTTPS
+   /// - The path, either absolute or relative, to a local torrent file
+   /// - A magnet URI
    pub async fn add_torrent(&self, metainfo_file_or_url: &str) -> Result<InfoHash, EngineError> {
       // Assuming this is a remote url to a torrent file
       let metainfo = if metainfo_file_or_url.starts_with("http") {

--- a/crates/libtortillas/src/engine/mod.rs
+++ b/crates/libtortillas/src/engine/mod.rs
@@ -68,8 +68,9 @@ pub struct Engine {
 }
 
 impl Engine {
-   /// Starts the torrenting process for a given torrent. The spawned [Torrent
-   /// Actor](Torrent) will be controlled by the [Engine]
+   /// Starts the torrenting process for a given torrent. This function
+   /// automatically contacts trackers and connects to peers. The spawned
+   /// [Torrent Actor](Torrent) will be controlled by the [Engine].
    ///
    /// This function accepts the following as input:
    /// - A remote URL to a torrent file over HTTP/HTTPS
@@ -79,7 +80,42 @@ impl Engine {
    /// If the inputted value is a remote url to a torrent file, this function
    /// requests the bytes and deserializes them into a [TorrentFile]. If
    /// it isn't, we assume that it is either a magnet URI or a path to a
-   /// torrent file, and pass the string to [MetaInfo::new()].
+   /// torrent file, and pass the string to [MetaInfo::new].
+   ///
+   ///
+   /// # Examples
+   ///
+   /// With a remote torrent file
+   /// ```no_run
+   /// use libtortillas::Engine;
+   ///
+   /// #[tokio::main]
+   /// async fn main() {
+   ///    let mut engine = Engine::new(todo!());
+   ///    let torrent_key = engine
+   ///       .add_torrent("https://mydomain.com/video.torrent")
+   ///       .await
+   ///       .expect("Failed to add torrent");
+   ///
+   ///    println!("Started Torrenting: {}", torrent_key);
+   /// }
+   /// ```
+   ///
+   /// With a magnet URI
+   /// ```no_run
+   /// use libtortillas::Engine;
+   ///
+   /// #[tokio::main]
+   /// async fn main() {
+   ///    let mut engine = Engine::new(todo!);
+   ///    let magnet_uri = "magnet:?xt=?????";
+   ///    let torrent_key = engine.add_torrent(magnet_uri)
+   ///       .await
+   ///       .expect("Failed to add torrent");
+   ///
+   ///    println!("Started Torrenting: {}", torrent_key);
+   /// }
+   /// ```
    pub async fn add_torrent(&self, metainfo: &str) -> Result<InfoHash, EngineError> {
       // File paths should either start with "/" or "./", and magnet URIs start
       // with "magnet:", so a check like this should be entirely appropriate.

--- a/crates/libtortillas/src/errors.rs
+++ b/crates/libtortillas/src/errors.rs
@@ -44,6 +44,10 @@ pub enum EngineError {
    #[error(transparent)]
    MetaInfoFetchError(#[from] reqwest::Error),
 
+   /// Failed to deserialize [MetaInfo](crate::metainfo::MetaInfo)
+   #[error("Failed to deserialize meta info")]
+   MetaInfoDeserializeError,
+
    /// Any other engine-level error wrapped in [`anyhow::Error`]
    #[error(transparent)]
    Other(#[from] anyhow::Error),

--- a/crates/libtortillas/src/errors.rs
+++ b/crates/libtortillas/src/errors.rs
@@ -40,6 +40,10 @@ pub enum EngineError {
    #[error("Network setup failed: {0}")]
    NetworkSetupFailed(String),
 
+   /// Failed to fetch [crate::metainfo::MetaInfo]
+   #[error(transparent)]
+   MetaInfoFetchError(#[from] reqwest::Error),
+
    /// Any other engine-level error wrapped in [`anyhow::Error`]
    #[error(transparent)]
    Other(#[from] anyhow::Error),


### PR DESCRIPTION
#105 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Add torrents directly from remote .torrent URLs or magnet links through a single API call.
  * Improved error feedback when fetching or parsing torrent metadata fails.

* **Documentation**
  * Added usage examples demonstrating how to add torrents from a URL and from a magnet URI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->