### PR TITLE
fix: Check if peer is already connected before inserting

### DIFF
--- a/crates/libtortillas/src/torrent/mod.rs
+++ b/crates/libtortillas/src/torrent/mod.rs
@@ -132,6 +132,13 @@ impl Torrent {
          if id == our_id {
             return;
          }
+
+         // #109
+         if peers.contains_key(&id) {
+            warn!("Peer already exists, ignoring");
+            return;
+         }
+
          peer.id = Some(id);
 
          let actor = PeerActor::spawn((peer.clone(), stream, actor_ref));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents duplicate peers from being added, avoiding redundant connections and improving network stability.
  * Reduces unnecessary resource usage by ignoring already-known peers.
  * Emits a warning in logs when a duplicate peer is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->