### PR TITLE
fix: Remove thread panics when peer connection refuses

### DIFF
--- a/crates/libtortillas/src/errors.rs
+++ b/crates/libtortillas/src/errors.rs
@@ -127,6 +127,10 @@ pub enum PeerActorError {
    #[error(transparent)]
    Io(#[from] std::io::Error),
 
+   /// [uTP](https://github.com/ikatson/librqbit-utp) error
+   #[error(transparent)]
+   Utp(#[from] librqbit_utp::Error),
+
    /// Any other peer-level error wrapped in `anyhow::Error`
    #[error(transparent)]
    Other(#[from] anyhow::Error),


### PR DESCRIPTION
Sometimes, peers just don't connect to use at all (due to the nature of the internet), and currently, it will crash our entire thread if a peer fails to connect due to our careless usage of unwrap. This PR intends to fix that.

This is done by changing `PeerStream::connect` into a `Result` instead of just unwrapping it (no clue why we didn't do this originally).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - Prevents crashes during TCP/uTP connection attempts and handshakes by properly returning errors instead of panicking.
  - Improves robustness when uTP is enabled, handling failures gracefully.
- Refactor
  - Stream connection flow updated to propagate errors, preserving concurrent TCP/uTP attempts while avoiding unwraps.
- Chores
  - Adds clearer log messages for connection failures to aid diagnostics.

Impact: More reliable peer connections, clearer error reporting, and fewer unexpected terminations during peer setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->