### PR TITLE
ci: Add documentation linting to ci checks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -61,3 +61,6 @@ jobs:
 
       - name: 💅 Run format checker
         run: cargo fmt --check
+        
+      - name: 📖 Run doc linter
+        run: cargo doc --no-deps --document-private-items


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded CI checks by adding a documentation build step to the lint job.
  * Generates project documentation (including private items) during CI to catch doc-related issues early.
  * This step runs after the format checker and can fail the lint job if documentation errors occur.
  * No changes to runtime behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->