### PR TITLE
perf: Changed all uses of BitVec to Arc<BitVec>

### DIFF
--- a/crates/libtortillas/Cargo.toml
+++ b/crates/libtortillas/Cargo.toml
@@ -22,7 +22,7 @@ tokio-stream = "0.1"
 thiserror = "2.0.12"
 async-trait = "0.1.88"
 librqbit-utp = "0.6.2"
-bitvec = { version = "1.0.1", features = ["atomic"] }
+bitvec = "1.0.1"
 futures = "0.3"
 bencode = "0.1.16"
 serde_with = "3.14.0"

--- a/crates/libtortillas/Cargo.toml
+++ b/crates/libtortillas/Cargo.toml
@@ -22,7 +22,7 @@ tokio-stream = "0.1"
 thiserror = "2.0.12"
 async-trait = "0.1.88"
 librqbit-utp = "0.6.2"
-bitvec = "1.0.1"
+bitvec = { version = "1.0.1", features = ["atomic"] }
 futures = "0.3"
 bencode = "0.1.16"
 serde_with = "3.14.0"

--- a/crates/libtortillas/src/peer/actor.rs
+++ b/crates/libtortillas/src/peer/actor.rs
@@ -173,16 +173,8 @@ impl PeerActor {
       let is_our_bitfield_empty = our_bitfield.is_empty();
 
       // Find pieces the peer has that we don't have
-      let their_bitfield = their_bitfield
-         .as_raw_slice()
-         .iter()
-         .map(|byte| byte.load(Ordering::Acquire))
-         .collect::<BitVec<u8>>();
-      let our_bitfield = our_bitfield
-         .as_raw_slice()
-         .iter()
-         .map(|byte| byte.load(Ordering::Acquire))
-         .collect::<BitVec<u8>>();
+      let their_bitfield = (*their_bitfield).clone();
+      let our_bitfield = (*our_bitfield).clone();
       let peer_has_we_dont = their_bitfield & !our_bitfield;
 
       let has_interesting_pieces = peer_has_we_dont.any();

--- a/crates/libtortillas/src/peer/actor.rs
+++ b/crates/libtortillas/src/peer/actor.rs
@@ -1,9 +1,6 @@
 use std::{
    collections::HashMap,
-   sync::{
-      Arc,
-      atomic::{AtomicU8, Ordering},
-   },
+   sync::{Arc, atomic::AtomicU8},
    time::Instant,
 };
 

--- a/crates/libtortillas/src/peer/mod.rs
+++ b/crates/libtortillas/src/peer/mod.rs
@@ -8,6 +8,7 @@ use std::{
    fmt::{self, Debug, Display},
    hash::{Hash as InternalHash, Hasher},
    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+   sync::{Arc, atomic::AtomicU8},
 };
 
 pub(crate) use actor::*;
@@ -32,7 +33,7 @@ pub struct Peer {
    pub ip: IpAddr,
    pub port: u16,
    pub state: PeerState,
-   pub pieces: BitVec<u8>,
+   pub pieces: Arc<BitVec<AtomicU8>>,
    /// The reserved bytes that the peer sent us in their handshake. This
    /// indicates what extensions the peer supports.
    pub reserved: [u8; 8],
@@ -80,7 +81,7 @@ impl Peer {
          ip,
          port,
          state: PeerState::new(),
-         pieces: BitVec::EMPTY,
+         pieces: Arc::new(BitVec::EMPTY),
          reserved: [0u8; 8],
          peer_supports: PeerSupports::new(),
          id: None,

--- a/crates/libtortillas/src/protocol/messages.rs
+++ b/crates/libtortillas/src/protocol/messages.rs
@@ -258,13 +258,13 @@ impl PeerMessages {
          }
          5 => {
             trace!(bitfield_len = payload.len(), "Received Bitfield message");
-            // We should definitely come back to this in the future. If you know how to get
+            // We should come back to this in the future. If you know how to get
             // the code below working, *please* make a PR.
             //
             // let bytes = bytes.into_iter();
             // let bytes = bytes.map(|byte| AtomicU8::new(byte)).collect();
-            let mut atomicu8_bytes = vec![];
-            for byte in bytes {
+            let mut atomicu8_bytes = Vec::with_capacity(payload.len());
+            for byte in payload {
                atomicu8_bytes.push(AtomicU8::new(byte));
             }
             Ok(PeerMessages::Bitfield(Arc::new(BitVec::from_slice(

--- a/crates/libtortillas/src/protocol/messages.rs
+++ b/crates/libtortillas/src/protocol/messages.rs
@@ -258,18 +258,10 @@ impl PeerMessages {
          }
          5 => {
             trace!(bitfield_len = payload.len(), "Received Bitfield message");
-            // We should come back to this in the future. If you know how to get
-            // the code below working, *please* make a PR.
-            //
-            // let bytes = bytes.into_iter();
-            // let bytes = bytes.map(|byte| AtomicU8::new(byte)).collect();
-            let mut atomicu8_bytes = Vec::with_capacity(payload.len());
-            for byte in payload {
-               atomicu8_bytes.push(AtomicU8::new(byte));
-            }
-            Ok(PeerMessages::Bitfield(Arc::new(BitVec::from_slice(
-               &atomicu8_bytes,
-            ))))
+
+            let bitvec: BitVec<AtomicU8> = payload.into_iter().map(AtomicU8::new).collect();
+
+            Ok(PeerMessages::Bitfield(Arc::new(bitvec)))
          }
          6 => {
             if payload.len() != 12 {


### PR DESCRIPTION
See #120

While the single commit in this PR is labeled as a feature, this PR is technically a performance focused PR. This is because this PR removes a number of unnecessary large clones made when handling peers' bitfields. See the linked issue for more information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - More accurate peer interest detection, especially when our piece set is empty.
  - Reliable handling of incoming HAVE messages to update local piece state.

- Refactor
  - Bitfield storage moved to a shared, thread-safe representation for peers and torrents, improving concurrency and responsiveness.
  - Message serialization/deserialization updated to handle the shared bitfield representation.

- Breaking
  - Public APIs now expose the shared atomic-backed bitfield type; downstream updates may be required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->