### PR TITLE
feat: handle WeakActorRef::upgrade() failure gracefully

### DIFF
--- a/crates/libtortillas/src/engine/actor.rs
+++ b/crates/libtortillas/src/engine/actor.rs
@@ -113,9 +113,15 @@ impl Actor for EngineActor {
          peer_stream = self.tcp_socket.accept() => match peer_stream {
             Ok((stream, _)) => {
                let peer_stream = Box::new(PeerStream::Tcp(stream));
+
+               let Some(actor_ref) = actor_ref.upgrade() else {
+                  error!("Failed to upgrade weak actor reference");
+                  return None;
+               };
+
                Some(Signal::Message {
                   message: Box::new(EngineMessage::IncomingPeer(peer_stream)),
-                  actor_ref: actor_ref.upgrade().unwrap(),
+                  actor_ref,
                   reply: None,
                   sent_within_actor: true,
                })
@@ -128,9 +134,15 @@ impl Actor for EngineActor {
          peer_stream = self.utp_socket.accept() => match peer_stream {
             Ok(stream) => {
                let peer_stream = Box::new(PeerStream::Utp(stream));
+
+               let Some(actor_ref) = actor_ref.upgrade() else {
+                  error!("Failed to upgrade weak actor reference");
+                  return None;
+               };
+
                Some(Signal::Message {
                   message: Box::new(EngineMessage::IncomingPeer(peer_stream)),
-                  actor_ref: actor_ref.upgrade().unwrap(),
+                  actor_ref,
                   reply: None,
                   sent_within_actor: true,
                })

--- a/crates/libtortillas/src/peer/actor.rs
+++ b/crates/libtortillas/src/peer/actor.rs
@@ -279,9 +279,15 @@ impl Actor for PeerActor {
       tokio::select! {
          signal = mailbox_rx.recv() => signal,
          msg = self.stream.recv() => {
+
+            let Some(actor_ref) = actor_ref.upgrade() else {
+               error!("Failed to upgrade weak actor reference");
+               return None;
+            };
+
             Some(Signal::Message {
                message: Box::new(msg.expect("PeerStream closed")),
-               actor_ref: actor_ref.upgrade().unwrap(),
+               actor_ref,
                reply: None,
                sent_within_actor: true,
             })


### PR DESCRIPTION
I'm 90% sure adding a check for this is necessary. Even if it isn't, it's not a bad check to make. Closes #129 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in peer connection management to prevent potential crashes during network operations when peer connections are unexpectedly closed or dropped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->