### PR TITLE
refactor: House keeping of  `PeerId`

### DIFF
--- a/crates/libtortillas/src/peer/id.rs
+++ b/crates/libtortillas/src/peer/id.rs
@@ -60,7 +60,7 @@ macro_rules! define_clients {
          format: $format:expr
       }
    ),* $(,)?) => {
-      #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+      #[derive(Copy, Clone, PartialEq, Eq, Hash)]
       pub enum PeerId {
          $($variant(Id),)*
          Unknown(Id),


### PR DESCRIPTION
Allows for pre-released tag stripping and fixes up some `Display` and `Debug` implementations.


Fixes: #145

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved peer identifier version encoding to extract and enforce a 4-digit numeric segment, increasing compatibility and preventing invalid version representations.
  - Display formatting simplified: peers now show "client_name version" (or just name) instead of including raw ID.

- Tests
  - Updated tests to match the new digits-only version extraction and ID layout expectations.

- Documentation
  - Minor punctuation fix in protocol format comment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->