### PR TITLE
feat: Implement a blocking start method & auto starting functionality

### DIFF
--- a/crates/libtortillas/src/engine/actor.rs
+++ b/crates/libtortillas/src/engine/actor.rs
@@ -51,6 +51,11 @@ pub struct EngineActor {
 
    /// Mailbox size for each torrent instance
    pub(crate) mailbox_size: usize,
+
+   /// If we autostart torrents
+   pub(crate) autostart: Option<bool>,
+   /// How many peers we need to have before we start downloading
+   pub(crate) sufficient_peers: Option<usize>,
 }
 
 pub(crate) type EngineActorArgs = (
@@ -67,6 +72,10 @@ pub(crate) type EngineActorArgs = (
    // Defaults to 64
    //
    // If 0 is provided, the mailbox size will be unbounded
+   Option<usize>,
+   // If we autostart torrents
+   Option<bool>,
+   // How many peers we need to have before we start downloading
    Option<usize>,
 );
 
@@ -86,8 +95,16 @@ impl Actor for EngineActor {
    async fn on_start(
       args: Self::Args, actor_ref: kameo::prelude::ActorRef<Self>,
    ) -> Result<Self, Self::Error> {
-      let (tcp_addr, utp_addr, udp_addr, peer_id, default_piece_storage_strategy, mailbox_size) =
-         args;
+      let (
+         tcp_addr,
+         utp_addr,
+         udp_addr,
+         peer_id,
+         default_piece_storage_strategy,
+         mailbox_size,
+         autostart,
+         sufficient_peers,
+      ) = args;
 
       let tcp_addr = tcp_addr.unwrap_or_else(|| SocketAddr::from(([0, 0, 0, 0], 0)));
       // Should this be port 6881?
@@ -112,6 +129,8 @@ impl Actor for EngineActor {
          actor_ref,
          default_piece_storage_strategy,
          mailbox_size: mailbox_size.unwrap_or(64),
+         autostart,
+         sufficient_peers,
       })
    }
 

--- a/crates/libtortillas/src/engine/messages.rs
+++ b/crates/libtortillas/src/engine/messages.rs
@@ -14,7 +14,7 @@ use crate::{
       messages::PeerMessages,
       stream::{PeerRecv, PeerStream},
    },
-   torrent::{TorrentActor, TorrentMessage},
+   torrent::{TorrentActor, TorrentMessage, TorrentState},
 };
 
 pub(crate) enum EngineMessage {
@@ -64,7 +64,7 @@ impl Message<EngineMessage> for EngineActor {
          EngineMessage::StartAll => {
             for torrent in self.torrents.iter() {
                torrent
-                  .tell(TorrentMessage::Start)
+                  .tell(TorrentMessage::SetState(TorrentState::Downloading))
                   .await
                   .expect("Failed to start torrent");
             }

--- a/crates/libtortillas/src/engine/messages.rs
+++ b/crates/libtortillas/src/engine/messages.rs
@@ -104,6 +104,8 @@ impl Message<EngineRequest> for EngineActor {
                   self.udp_server.clone(),
                   None,
                   self.default_piece_storage_strategy.clone(),
+                  self.autostart,
+                  self.sufficient_peers,
                ),
                // if the size is 0, we use an unbounded mailbox
                match self.mailbox_size {

--- a/crates/libtortillas/src/engine/mod.rs
+++ b/crates/libtortillas/src/engine/mod.rs
@@ -114,6 +114,16 @@ impl Engine {
       ///
       /// Default: `64` when `None` is provided.
       mailbox_size: Option<usize>,
+      /// If we autostart torrents as soon as we have [`Self::sufficient_peers`]
+      /// peers connected.
+      /// Default: `true`
+      autostart: Option<bool>,
+      /// How many peers we need to have before we start downloading.
+      ///
+      /// Is ignored if [`Self::autostart`] is `false`.
+      ///
+      /// Default: `6`
+      sufficient_peers: Option<usize>,
    ) -> Self {
       let args: EngineActorArgs = (
          tcp_addr,
@@ -122,6 +132,8 @@ impl Engine {
          Some(custom_id),
          piece_storage_strategy,
          mailbox_size,
+         autostart,
+         sufficient_peers,
       );
 
       let actor = EngineActor::spawn(args);

--- a/crates/libtortillas/src/torrent/actor.rs
+++ b/crates/libtortillas/src/torrent/actor.rs
@@ -608,30 +608,6 @@ mod tests {
          PieceStorageStrategy::Disk(piece_path.clone()),
       ));
 
-      //// Blocking loop that runs until we successfully handshake with atleast 6
-      //// peers
-      // loop {
-      //   let peers_count = match actor.ask(TorrentRequest::PeerCount).await.unwrap()
-      // {      TorrentResponse::PeerCount(count) => count,
-      //      _ => unreachable!(),
-      //   };
-      //   if peers_count > 6 {
-      //      break;
-      //   } else {
-      //      info!(
-      //         current_peers_count = peers_count,
-      //         "Waiting for more peers...."
-      //      )
-      //   }
-      //   sleep(Duration::from_millis(100)).await;
-      //}
-      // clear_piece_files(&piece_path).await;
-      //
-      // actor
-      //   .tell(TorrentMessage::SetState(TorrentState::Downloading))
-      //   .await
-      //   .unwrap();
-      //
       loop {
          let mut entries = fs::read_dir(&piece_path).await.unwrap();
          let mut found_piece = false;

--- a/crates/libtortillas/src/torrent/actor.rs
+++ b/crates/libtortillas/src/torrent/actor.rs
@@ -62,7 +62,8 @@ pub enum PieceStorageStrategy {
    Disk(PathBuf),
 }
 
-/// The current state of the torrent, defaults to `Paused`
+/// The current state of the torrent, defaults to
+/// [`Inactive`](TorrentState::Inactive)
 #[derive(Debug, Default, Clone, Copy)]
 pub enum TorrentState {
    /// Torrent is downloading new pieces actively

--- a/crates/libtortillas/src/torrent/actor.rs
+++ b/crates/libtortillas/src/torrent/actor.rs
@@ -205,10 +205,9 @@ impl TorrentActor {
             .broadcast_to_peers(PeerTell::NeedPiece(self.next_piece, 0, BLOCK_SIZE))
             .await;
          self.start_time = Some(Instant::now());
-
-         if let Some(err) = self.ready_hook.take().and_then(|hook| hook.send(()).err()) {
-            error!(?err, "Failed to send ready hook");
-         }
+      }
+      if let Some(err) = self.ready_hook.take().and_then(|hook| hook.send(()).err()) {
+         error!(?err, "Failed to send ready hook");
       }
    }
 

--- a/crates/libtortillas/src/torrent/actor.rs
+++ b/crates/libtortillas/src/torrent/actor.rs
@@ -64,7 +64,7 @@ pub enum PieceStorageStrategy {
 
 /// The current state of the torrent, defaults to
 /// [`Inactive`](TorrentState::Inactive)
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TorrentState {
    /// Torrent is downloading new pieces actively
    ///

--- a/crates/libtortillas/src/torrent/actor.rs
+++ b/crates/libtortillas/src/torrent/actor.rs
@@ -114,7 +114,7 @@ pub(crate) struct TorrentActor {
    pub(super) autostart: bool,
 
    /// If there is already a pending start, we don't want to start a new one
-   pending_start: bool,
+   pub(super) pending_start: bool,
 
    pub(super) ready_hook: Option<ReadyHook>,
 }

--- a/crates/libtortillas/src/torrent/actor.rs
+++ b/crates/libtortillas/src/torrent/actor.rs
@@ -173,10 +173,7 @@ impl TorrentActor {
 
       self.pending_start = true;
 
-      let is_ready = self.state == TorrentState::Inactive
-         && self.info.is_some()
-         && self.peers.len() > self.sufficient_peers;
-
+      let is_ready = self.is_ready_to_start();
       if is_ready {
          if self.autostart {
             trace!("Autostarting torrent");
@@ -220,6 +217,14 @@ impl TorrentActor {
    /// zeroes.
    pub fn is_full(&self) -> bool {
       self.bitfield.count_ones() == self.bitfield.len()
+   }
+
+   pub fn is_ready(&self) -> bool {
+      self.info.is_some() && self.peers.len() >= self.sufficient_peers
+   }
+
+   pub fn is_ready_to_start(&self) -> bool {
+      self.is_ready() && self.state == TorrentState::Inactive
    }
 
    /// Spawns a new [`PeerActor`] for the given [`Peer`] and adds it to the

--- a/crates/libtortillas/src/torrent/actor.rs
+++ b/crates/libtortillas/src/torrent/actor.rs
@@ -191,6 +191,7 @@ impl TorrentActor {
          self
             .broadcast_to_peers(PeerTell::NeedPiece(self.next_piece, 0, BLOCK_SIZE))
             .await;
+         self.start_time = Some(Instant::now());
       }
    }
 

--- a/crates/libtortillas/src/torrent/messages.rs
+++ b/crates/libtortillas/src/torrent/messages.rs
@@ -307,24 +307,8 @@ impl Message<TorrentMessage> for TorrentActor {
          }
          TorrentMessage::SetState(state) => {
             self.state = state;
-
-            match &self.state {
-               TorrentState::Downloading => {
-                  info!(id = %self.info_hash(), "Torrent is now downloading");
-
-                  trace!(id = %self.info_hash(), peer_count = self.peers.len(), "Requesting first piece from peers");
-
-                  // Request first piece from peers
-                  self
-                     .broadcast_to_peers(PeerTell::NeedPiece(self.next_piece, 0, BLOCK_SIZE))
-                     .await;
-               }
-               TorrentState::Seeding => {
-                  info!(id = %self.info_hash(), "Torrent is now seeding");
-               }
-               TorrentState::Inactive => {
-                  info!(id = %self.info_hash(), "Torrent is now inactive");
-               }
+            if let TorrentState::Downloading = state {
+               self.start().await;
             }
          }
       }

--- a/crates/libtortillas/src/torrent/messages.rs
+++ b/crates/libtortillas/src/torrent/messages.rs
@@ -322,9 +322,15 @@ impl Message<TorrentMessage> for TorrentActor {
          }
          TorrentMessage::SetAutoStart(auto) => {
             self.autostart = auto;
+            if !self.pending_start {
+               self.autostart().await;
+            }
          }
          TorrentMessage::SetSufficientPeers(peers) => {
             self.sufficient_peers = peers;
+            if !self.pending_start {
+               self.autostart().await;
+            }
          }
          TorrentMessage::ReadyHook(hook) => {
             // If torrent has already transitioned from Inactive state, immediately send

--- a/crates/libtortillas/src/torrent/messages.rs
+++ b/crates/libtortillas/src/torrent/messages.rs
@@ -57,6 +57,10 @@ pub(crate) enum TorrentMessage {
    PieceStorage(PieceStorageStrategy),
    /// Start the torrenting process & actually start downloading pieces/seeding
    SetState(TorrentState),
+
+   SetAutoStart(bool),
+
+   SetSufficientPeers(usize),
 }
 
 impl fmt::Debug for TorrentMessage {
@@ -310,6 +314,12 @@ impl Message<TorrentMessage> for TorrentActor {
             if let TorrentState::Downloading = state {
                self.start().await;
             }
+         }
+         TorrentMessage::SetAutoStart(auto) => {
+            self.autostart = auto;
+         }
+         TorrentMessage::SetSufficientPeers(peers) => {
+            self.sufficient_peers = peers;
          }
       }
    }

--- a/crates/libtortillas/src/torrent/messages.rs
+++ b/crates/libtortillas/src/torrent/messages.rs
@@ -327,7 +327,13 @@ impl Message<TorrentMessage> for TorrentActor {
             self.sufficient_peers = peers;
          }
          TorrentMessage::ReadyHook(hook) => {
-            self.ready_hook = Some(hook);
+            let is_ready = self.is_ready_to_start();
+            if is_ready && !self.autostart {
+               let _ = hook.send(());
+            } else {
+               self.ready_hook = Some(hook);
+               self.autostart().await;
+            }
          }
       }
    }

--- a/crates/libtortillas/src/torrent/messages.rs
+++ b/crates/libtortillas/src/torrent/messages.rs
@@ -106,8 +106,8 @@ actor_request_response!(
    OutputStrategy(OutputStrategy)
    OutputStrategy(Option<mpsc::Receiver<StreamedPiece>>),
 
-   State
-   State(TorrentState),
+   GetState
+   GetState(TorrentState),
 );
 
 impl Message<TorrentMessage> for TorrentActor {
@@ -359,7 +359,7 @@ impl Message<TorrentRequest> for TorrentActor {
                unimplemented!()
             }
          },
-         TorrentRequest::State => TorrentResponse::State(self.state),
+         TorrentRequest::GetState => TorrentResponse::GetState(self.state),
       }
    }
 }

--- a/crates/libtortillas/src/torrent/messages.rs
+++ b/crates/libtortillas/src/torrent/messages.rs
@@ -327,12 +327,13 @@ impl Message<TorrentMessage> for TorrentActor {
             self.sufficient_peers = peers;
          }
          TorrentMessage::ReadyHook(hook) => {
-            // If torrent has already transitioned from Inactive state, immediately send ready signal
+            // If torrent has already transitioned from Inactive state, immediately send
+            // ready signal
             if self.state != TorrentState::Inactive {
                let _ = hook.send(());
                return;
             }
-            
+
             let is_ready = self.is_ready_to_start();
             if is_ready && !self.autostart {
                let _ = hook.send(());

--- a/crates/libtortillas/src/torrent/messages.rs
+++ b/crates/libtortillas/src/torrent/messages.rs
@@ -327,6 +327,12 @@ impl Message<TorrentMessage> for TorrentActor {
             self.sufficient_peers = peers;
          }
          TorrentMessage::ReadyHook(hook) => {
+            // If torrent has already transitioned from Inactive state, immediately send ready signal
+            if self.state != TorrentState::Inactive {
+               let _ = hook.send(());
+               return;
+            }
+            
             let is_ready = self.is_ready_to_start();
             if is_ready && !self.autostart {
                let _ = hook.send(());

--- a/crates/libtortillas/src/torrent/mod.rs
+++ b/crates/libtortillas/src/torrent/mod.rs
@@ -245,7 +245,7 @@ impl Torrent {
    ///
    /// Returns an error if the message could not be delivered to the actor.
    pub async fn start(&self) -> Result<(), anyhow::Error> {
-      let msg = TorrentMessage::Start;
+      let msg = TorrentMessage::SetState(TorrentState::Downloading);
 
       self
          .actor()

--- a/crates/libtortillas/src/torrent/mod.rs
+++ b/crates/libtortillas/src/torrent/mod.rs
@@ -274,4 +274,37 @@ impl Torrent {
          _ => unreachable!(),
       }
    }
+
+   /// If the torrent should automatically start when `sufficient_peers` is
+   /// met.
+   ///
+   /// If this is false, you are expected to poll/wait for the torrent and
+   /// manually start it using [`poll_ready`](Self::poll_ready) and
+   /// [`start`](Self::start).
+   ///
+   /// Default: `true`
+   pub async fn set_auto_start(&self, auto: bool) {
+      let msg = TorrentMessage::SetAutoStart(auto);
+      self
+         .actor()
+         .tell(msg)
+         .await
+         .expect("Failed to set auto start");
+   }
+
+   /// Sets the number of peers we need to have before we start downloading.
+   ///
+   /// Default: `6`
+   pub async fn set_sufficient_peers(&self, peers: usize) {
+      let msg = TorrentMessage::SetSufficientPeers(peers);
+      self
+         .actor()
+         .tell(msg)
+         .await
+         .expect("Failed to set sufficient peers");
+   }
+
+   pub async fn poll_ready(&self) -> Result<(), anyhow::Error> {
+      unimplemented!()
+   }
 }

--- a/crates/libtortillas/src/torrent/mod.rs
+++ b/crates/libtortillas/src/torrent/mod.rs
@@ -262,7 +262,7 @@ impl Torrent {
    ///
    /// Panics if the message could not be sent to the actor.
    pub async fn state(&self) -> TorrentState {
-      let msg = TorrentRequest::State;
+      let msg = TorrentRequest::GetState;
 
       match self
          .actor()
@@ -270,7 +270,7 @@ impl Torrent {
          .await
          .expect("Failed to send request for state")
       {
-         TorrentResponse::State(state) => state,
+         TorrentResponse::GetState(state) => state,
          _ => unreachable!(),
       }
    }

--- a/crates/libtortillas/src/torrent/mod.rs
+++ b/crates/libtortillas/src/torrent/mod.rs
@@ -304,6 +304,35 @@ impl Torrent {
          .expect("Failed to set sufficient peers");
    }
 
+   /// A blocking function that polls the torrent until it is ready to start
+   /// downloading.
+   ///
+   /// The criteria for when the torrent is ready to start is:
+   /// - We have sufficient peers (see [`Self::set_sufficient_peers`]), the
+   ///   default is `6`
+   /// - We have the info dict either from using a torrent file, or from a peer
+   ///
+   /// Required if you want to set [`Self::set_auto_start`] to `false`,
+   /// otherwise the torrent won't actually download anything.
+   ///
+   /// # Example
+   ///
+   /// ```no_run
+   /// use libtortillas::prelude::*;
+   ///
+   /// #[tokio::main]
+   /// async fn main() {
+   ///    let engine = Engine::default();
+   ///    let torrent = engine
+   ///       .add_torrent("https://example.com/file.torrent")
+   ///       .await
+   ///       .expect("Failed to add torrent");
+   ///
+   ///    torrent.set_auto_start(false).await;
+   ///    torrent.poll_ready().await.expect("Failed to poll torrent");
+   ///    torrent.start().await.expect("Failed to start torrent");
+   /// }
+   /// ```
    pub async fn poll_ready(&self) -> Result<(), anyhow::Error> {
       unimplemented!()
    }


### PR DESCRIPTION
Currently, in order to "wait until we're ready to start downloading", we have to run a loop to check if we have the info dict, and we have *sufficient peers*. This PR aims to create a centralized, and reusable way to "wait" until we are ready to start the downloading process. The features include:
- Adding a `poll_ready` function for "blocking" until we're ready to download
- Removing the `Start` message in favor of `SetState`
- Adding an `autostart` property to `TorrentActor` to tell the actor if it should start the torrent automatically or not (without having to be polled and explicitly told to start)
- Make the peers needed to start customizable (you can set the sufficient_peers)
- Make the engine provide defaults, and have each child `Torrent` derive from them
- Add a frontend API in the `Torrent` struct to interact with all of these things for fine tuning of the engine's defaults

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Optional autostart and peer-threshold settings for engine and torrents; configurable at creation and at runtime.
  - Runtime controls to toggle autostart and set required peer count.
  - poll_ready(): await a torrent becoming ready via a readiness hook before starting.

- **Refactor**
  - Torrent start now uses state-based control with an autostart/readiness flow.
  - Initialization and messaging updated to forward and honor autostart and sufficient-peers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->