### PR TITLE
feat: Write pieces to their respective files

### DIFF
--- a/crates/libtortillas/src/engine/actor.rs
+++ b/crates/libtortillas/src/engine/actor.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, path::PathBuf, sync::Arc};
 
 use dashmap::DashMap;
 use kameo::{
@@ -56,6 +56,8 @@ pub struct EngineActor {
    pub(crate) autostart: Option<bool>,
    /// How many peers we need to have before we start downloading
    pub(crate) sufficient_peers: Option<usize>,
+
+   pub(crate) default_base_path: Option<PathBuf>,
 }
 
 pub(crate) type EngineActorArgs = (
@@ -77,6 +79,8 @@ pub(crate) type EngineActorArgs = (
    Option<bool>,
    // How many peers we need to have before we start downloading
    Option<usize>,
+   // Default base path for torrents
+   Option<PathBuf>,
 );
 
 impl Actor for EngineActor {
@@ -104,6 +108,7 @@ impl Actor for EngineActor {
          mailbox_size,
          autostart,
          sufficient_peers,
+         default_base_path,
       ) = args;
 
       let tcp_addr = tcp_addr.unwrap_or_else(|| SocketAddr::from(([0, 0, 0, 0], 0)));
@@ -131,6 +136,7 @@ impl Actor for EngineActor {
          mailbox_size: mailbox_size.unwrap_or(64),
          autostart,
          sufficient_peers,
+         default_base_path,
       })
    }
 

--- a/crates/libtortillas/src/engine/messages.rs
+++ b/crates/libtortillas/src/engine/messages.rs
@@ -106,6 +106,7 @@ impl Message<EngineRequest> for EngineActor {
                   self.default_piece_storage_strategy.clone(),
                   self.autostart,
                   self.sufficient_peers,
+                  self.default_base_path.clone(),
                ),
                // if the size is 0, we use an unbounded mailbox
                match self.mailbox_size {

--- a/crates/libtortillas/src/engine/mod.rs
+++ b/crates/libtortillas/src/engine/mod.rs
@@ -37,7 +37,7 @@
 mod actor;
 mod messages;
 
-use std::net::SocketAddr;
+use std::{fs, net::SocketAddr, path::PathBuf};
 
 pub(crate) use actor::*;
 use bon;
@@ -124,7 +124,16 @@ impl Engine {
       ///
       /// Default: `6`
       sufficient_peers: Option<usize>,
+      /// Default base path for torrents
+      ///
+      /// Default: `std::env::current_dir()`
+      #[builder(into)]
+      output_path: Option<PathBuf>,
    ) -> Self {
+      let output_path = output_path
+         .map(|p| fs::canonicalize(p).expect("Failed to canonicalize path"))
+         .unwrap_or(std::env::current_dir().expect("Failed to get current dir"));
+
       let args: EngineActorArgs = (
          tcp_addr,
          utp_addr,
@@ -134,6 +143,7 @@ impl Engine {
          mailbox_size,
          autostart,
          sufficient_peers,
+         Some(output_path),
       );
 
       let actor = EngineActor::spawn(args);

--- a/crates/libtortillas/src/metainfo/file.rs
+++ b/crates/libtortillas/src/metainfo/file.rs
@@ -140,6 +140,13 @@ impl Info {
    pub fn piece_count(&self) -> usize {
       self.pieces.len()
    }
+   /// The total length of all the files in the torrent
+   pub fn total_length(&self) -> usize {
+      match &self.file {
+         InfoKeys::Single { length, .. } => *length as usize,
+         InfoKeys::Multi { files } => files.iter().map(|f| f.length).sum(),
+      }
+   }
 }
 
 #[cfg(test)]

--- a/crates/libtortillas/src/peer/actor.rs
+++ b/crates/libtortillas/src/peer/actor.rs
@@ -436,7 +436,7 @@ impl Message<PeerTell> for PeerActor {
    async fn handle(&mut self, msg: PeerTell, _: &mut KameoContext<Self, Self::Reply>) {
       match msg {
          PeerTell::NeedPiece(index, begin, length) => {
-            let piece_exists = self.peer.pieces[index];
+            let piece_exists = self.peer.pieces.get(index).is_some();
 
             if !piece_exists {
                trace!(

--- a/crates/libtortillas/src/torrent/messages.rs
+++ b/crates/libtortillas/src/torrent/messages.rs
@@ -12,13 +12,10 @@ use kameo::{
    prelude::{Context, Message},
 };
 use sha1::{Digest, Sha1};
-use tokio::{fs, sync::mpsc};
+use tokio::fs;
 use tracing::{debug, error, info, trace, warn};
 
-use super::{
-   BLOCK_SIZE, OutputStrategy, PieceStorageStrategy, ReadyHook, StreamedPiece, TorrentActor,
-   TorrentState, util,
-};
+use super::{BLOCK_SIZE, PieceStorageStrategy, ReadyHook, TorrentActor, TorrentState, util};
 use crate::{
    actor_request_response,
    hashes::InfoHash,
@@ -121,9 +118,6 @@ actor_request_response!(
    /// Requests a piece from the torrent
    Request(usize, usize, usize)
    Request(usize, usize, Bytes),
-   /// Asks the Torrent Actor to use an output stream instead of writing the pieces to disk
-   OutputStrategy(OutputStrategy)
-   OutputStrategy(Option<mpsc::Receiver<StreamedPiece>>),
 
    GetState
    GetState(TorrentState),
@@ -407,14 +401,6 @@ impl Message<TorrentRequest> for TorrentActor {
          TorrentRequest::Request(_, _, _) => {
             unimplemented!()
          }
-         TorrentRequest::OutputStrategy(strategy) => match strategy {
-            OutputStrategy::Folder(_) => {
-               unimplemented!()
-            }
-            OutputStrategy::Stream => {
-               unimplemented!()
-            }
-         },
          TorrentRequest::GetState => TorrentResponse::GetState(self.state),
       }
    }

--- a/crates/libtortillas/src/torrent/mod.rs
+++ b/crates/libtortillas/src/torrent/mod.rs
@@ -8,6 +8,7 @@ use bytes::Bytes;
 use kameo::actor::ActorRef;
 pub(crate) use messages::*;
 use tokio::sync::{mpsc, oneshot};
+use tokio::sync::oneshot;
 use tracing::error;
 
 pub mod util;
@@ -117,6 +118,7 @@ impl Torrent {
    /// Specifies the output folder that each file will eventually be written to.
    ///
    /// This function or [`Self::with_output_stream`] is strictly required to be
+   /// This function or [`Self::with_piece_manager`] is strictly required to be
    /// set before the download begins.
    ///
    /// # Examples
@@ -200,6 +202,7 @@ impl Torrent {
    /// }
    /// ```
    pub async fn with_output_stream<'a>(&'a self, piece_manager: impl PieceManager + 'a + 'static) {
+   pub async fn with_piece_manager<'a>(&'a self, piece_manager: impl PieceManager + 'a + 'static) {
       self
          .actor()
          .tell(TorrentMessage::PieceManager(Box::new(piece_manager)))

--- a/crates/libtortillas/src/torrent/mod.rs
+++ b/crates/libtortillas/src/torrent/mod.rs
@@ -7,7 +7,6 @@ pub use actor::*;
 use bytes::Bytes;
 use kameo::actor::ActorRef;
 pub(crate) use messages::*;
-use tokio::sync::{mpsc, oneshot};
 use tokio::sync::oneshot;
 use tracing::error;
 

--- a/crates/libtortillas/src/torrent/piece_manager.rs
+++ b/crates/libtortillas/src/torrent/piece_manager.rs
@@ -1,70 +1,179 @@
-use std::path::PathBuf;
+use std::{io::SeekFrom, path::PathBuf};
 
+use anyhow::ensure;
 use async_trait::async_trait;
 use bytes::Bytes;
+use tokio::{
+   fs::OpenOptions,
+   io::{AsyncSeekExt, AsyncWriteExt},
+};
 
-use super::util;
-use crate::prelude::{Info, InfoKeys};
+use crate::metainfo::{Info, InfoKeys};
+
 #[allow(unused)]
 #[async_trait]
 pub trait PieceManager: Clone + Send + Sync {
-   async fn pre_start(&self, info: Info) -> anyhow::Result<()>;
-   async fn recv(&self, filename: String, index: usize, offset: usize, data: Bytes);
-}
+   fn info(&self) -> Option<&Info>;
+   async fn pre_start(&mut self, info: Info) -> anyhow::Result<()>;
+   async fn recv(&self, index: usize, data: Bytes) -> anyhow::Result<()>;
 
-#[allow(unused)]
-#[derive(Clone)]
-pub struct FilePieceManager {
-   piece_length: usize,
-   total_length: usize,
-   base_path: PathBuf,
-}
+   /// Maps a torrent piece index to the corresponding file segments on disk.
+   ///
+   /// Each piece is a contiguous chunk of the torrent's data, but in multi-file
+   /// torrents, a piece may span across multiple files. This function
+   /// determines which file(s) contain the given piece and at what offsets.
+   ///
+   /// # Returns
+   /// A [`Vec<(PathBuf, usize, usize)>`] where each tuple contains:
+   /// - [`PathBuf`] → the file’s path within the torrent
+   /// - [`usize`]   → the byte offset inside that file where the piece data
+   ///   starts
+   /// - [`usize`]   → the number of bytes from that file that belong to the
+   ///   piece
+   ///
+   /// # Errors
+   /// - Returns an error if the torrent metadata (`info`) is missing.
+   /// - Returns an error if the piece index extends beyond the total torrent
+   ///   length.
+   ///
+   /// This ensures that every piece index is mapped precisely onto the
+   /// underlying file storage layout.
+   fn piece_to_paths(&self, index: usize) -> anyhow::Result<Vec<(PathBuf, usize, usize)>> {
+      let info = self.info().ok_or_else(|| anyhow::anyhow!("info not set"))?;
+      let piece_len = info.piece_length as usize;
+      let total_len = info.total_length();
 
-impl FilePieceManager {}
+      let piece_start = index * piece_len;
+      let piece_end = ((index + 1) * piece_len).min(total_len);
+      let mut remaining = piece_end - piece_start;
 
-#[async_trait]
-impl PieceManager for FilePieceManager {
-   async fn pre_start(&self, info_dict: Info) -> anyhow::Result<()> {
-      match info_dict.file {
+      let mut acc = 0;
+      let mut results = Vec::new();
+
+      match &info.file {
          InfoKeys::Single { length, .. } => {
-            util::create_empty_file(&info_dict.name, length as usize).await?;
-         }
+            // Single-file torrents just map to a single path = `name`
+            let file_len = *length as usize;
 
+            if piece_start < file_len {
+               let offset_in_file = piece_start;
+               let available_in_file = file_len - offset_in_file;
+               let take_len = remaining.min(available_in_file);
+
+               results.push((PathBuf::from(&info.name), offset_in_file, take_len));
+
+               remaining -= take_len;
+            }
+         }
          InfoKeys::Multi { files } => {
             for file in files {
-               util::create_empty_file(&file.path.concat(), file.length).await?;
+               let file_len = file.length;
+
+               // Skip files before the piece
+               if piece_start >= acc + file_len {
+                  acc += file_len;
+                  continue;
+               }
+
+               // Overlap with this file
+               let offset_in_file = piece_start.saturating_sub(acc);
+               let available_in_file = file_len - offset_in_file;
+               let take_len = remaining.min(available_in_file);
+
+               results.push((
+                  PathBuf::from_iter(file.path.clone()),
+                  offset_in_file,
+                  take_len,
+               ));
+
+               remaining -= take_len;
+               acc += file_len;
+
+               if remaining == 0 {
+                  break;
+               }
             }
          }
       }
+
+      ensure!(remaining == 0, "piece index {index} exceeds file lengths");
+      Ok(results)
+   }
+}
+#[derive(Debug, Clone)]
+struct FilePieceManager(PathBuf, Option<Info>);
+
+#[async_trait]
+impl PieceManager for FilePieceManager {
+   fn info(&self) -> Option<&Info> {
+      self.1.as_ref()
+   }
+
+   async fn pre_start(&mut self, info_dict: Info) -> anyhow::Result<()> {
+      self.1 = Some(info_dict);
       Ok(())
    }
 
    #[allow(unused)]
-   async fn recv(&self, filename: String, index: usize, offset: usize, data: Bytes) {}
+   async fn recv(&self, index: usize, data: Bytes) -> anyhow::Result<()> {
+      let base_path = &self.0;
+      let info = self.info().ok_or_else(|| anyhow::anyhow!("info not set"))?;
+
+      let piece_bounds = self.piece_to_paths(index)?;
+      let mut data_offset = 0; // Track how much of `data` we've consumed
+
+      for (path, file_offset, len) in piece_bounds {
+         let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(base_path.join(path))
+            .await?;
+
+         // Position file correctly
+         file.seek(SeekFrom::Start(file_offset as u64)).await?;
+
+         // Write correct slice from the piece buffer
+         file
+            .write_all(&data[data_offset..data_offset + len])
+            .await?;
+
+         data_offset += len;
+      }
+
+      Ok(())
+   }
 }
 
 #[cfg(test)]
 mod tests {
-   use tokio::fs;
-
    use super::*;
-
+   use crate::prelude::{MetaInfo, TorrentFile};
    #[tokio::test]
-   async fn test_create_empty_file() {
-      let temp_dir = std::env::temp_dir();
-      let path = temp_dir.join("tortillas-test");
+   async fn test_piece_paths() {
+      tracing_subscriber::fmt()
+         .with_target(true)
+         .with_env_filter("libtortillas=trace,off")
+         .pretty()
+         .init();
 
-      let _manager = FilePieceManager {
-         piece_length: 1024,
-         total_length: 1024,
-         base_path: path.clone(),
+      let path = std::env::current_dir().unwrap();
+
+      // Parse real torrent
+      let MetaInfo::Torrent(torrent) = TorrentFile::parse(include_bytes!(
+         "../../tests/torrents/big-buck-bunny.torrent"
+      ))
+      .unwrap() else {
+         panic!("failed to parse torrent file");
       };
+      let manager = FilePieceManager(path, Some(torrent.info));
 
-      util::create_empty_file(&path, 1_000).await.unwrap();
+      // Pick a few representative pieces
+      assert!(manager.piece_to_paths(0).is_ok());
 
-      assert!(path.exists());
+      let (file_path, _, _) = manager.piece_to_paths(0).unwrap()[0].clone();
 
-      // This is not absolutely necessary, but it is the appropriate thing to do.
-      fs::remove_file(path.clone()).await.unwrap();
+      // The first file should always be "Big Buck Bunny.en.srt"
+      assert_eq!(file_path.extension().unwrap(), "srt");
    }
 }

--- a/crates/libtortillas/src/torrent/piece_manager.rs
+++ b/crates/libtortillas/src/torrent/piece_manager.rs
@@ -17,7 +17,7 @@ pub trait PieceManager: Clone + Send + Sync {
    async fn pre_start(&mut self, info: Info) -> anyhow::Result<()>;
    async fn recv(&self, index: usize, data: Bytes) -> anyhow::Result<()>;
 
-   /// Maps a torrent piece index to the corresponding file segments on disk.
+   /// Maps a torrent piece index to its corresponding file segments.
    ///
    /// Each piece is a contiguous chunk of the torrent's data, but in multi-file
    /// torrents, a piece may span across multiple files. This function
@@ -25,10 +25,10 @@ pub trait PieceManager: Clone + Send + Sync {
    ///
    /// # Returns
    /// A [`Vec<(PathBuf, usize, usize)>`] where each tuple contains:
-   /// - [`PathBuf`] → the file’s path within the torrent
-   /// - [`usize`]   → the byte offset inside that file where the piece data
+   /// - [`PathBuf`] -> the file’s path within the torrent
+   /// - [`usize`]   -> the byte offset inside that file where the piece data
    ///   starts
-   /// - [`usize`]   → the number of bytes from that file that belong to the
+   /// - [`usize`]   -> the number of bytes from that file that belong to the
    ///   piece
    ///
    /// # Errors

--- a/crates/libtortillas/src/torrent/piece_manager.rs
+++ b/crates/libtortillas/src/torrent/piece_manager.rs
@@ -7,7 +7,7 @@ use tokio::{
    fs::OpenOptions,
    io::{AsyncSeekExt, AsyncWriteExt},
 };
-use tracing::{debug, trace};
+use tracing::debug;
 
 use crate::metainfo::{Info, InfoKeys};
 


### PR DESCRIPTION
This PR:
- Creates a reusable trait called `PieceManager` to allow users to create and manage pieces independently 
- Demuxes each piece into a `Vec<(PathBuf, usize, usize)>` containing information needed to write it to a file(s)
- Creates a default `FilePieceManager` that implements `PieceManager` for writing each piece to the correct file.
- Creates a frontend API for creating custom piece managers
- Inforces the use of the `Disk` piece storage strategy when using a custom `PieceManager`

Issues this closes:
- #126 
- #137
- #136