### PR TITLE
refactor: Rename variables in `state.rs`

### DIFF
--- a/crates/libtortillas/src/peer/state.rs
+++ b/crates/libtortillas/src/peer/state.rs
@@ -33,11 +33,11 @@ pub struct PeerState {
    download_rate: Arc<AtomicUsize>,
    /// Upload rate measured in kilobytes per second
    upload_rate: Arc<AtomicUsize>,
-   /// The remote peer's choke status
+   /// Whether we are choking the remote peer
    am_choking: Arc<AtomicBool>,
-   /// The remote peer's interest status
+   /// Whether the remote peer is interested in us
    pub(crate) peer_interested: Arc<AtomicBool>,
-   /// Our choke status
+   /// Whether the remote peer is choking us
    pub(crate) peer_choking: Arc<AtomicBool>,
    /// Our interest status
    am_interested: Arc<AtomicBool>,


### PR DESCRIPTION
- Change `choked` to `am_choking`, `interested` to `peer_interested` and `am_choked` to `peer_choking`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Renamed and realigned internal peer-state fields for clearer semantics and consistent initialization.
  - Updated accessors and mutators to match the new internal naming.
  - No changes to functionality, UI, settings, or performance; user workflows remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->