### PR TITLE
fix: Give `PeerMessages::KeepAlive` a `to_bytes` match branch

### DIFF
--- a/crates/libtortillas/src/protocol/messages.rs
+++ b/crates/libtortillas/src/protocol/messages.rs
@@ -203,7 +203,7 @@ impl PeerMessages {
             }
             create_message_with_id(20, &payload)
          }
-         PeerMessages::KeepAlive => Bytes::from(vec![0u8; 4]),
+         PeerMessages::KeepAlive => Bytes::from_static(&[0u8; 4]),
       })
    }
 


### PR DESCRIPTION
fixes #155 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly handles keep-alive messages to avoid spurious parsing errors.
  * Sends and recognizes protocol-compliant 4-byte keep-alive frames.
  * Improves connection stability and reduces unexpected disconnects during idle periods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->