### PR TITLE
chore: Remove call-to-action in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,9 +106,3 @@ This log level should be for:
 #### `error!`
 This log level should be for:
 - A critical error that the user should know about
-
----
-
-✅ Now the **Workflow** section explicitly links to the **Pull Requests** section for merge requirements.  
-
-Would you like me to also add a **"Quick Reference Checklist"** at the bottom (like a contributor TL;DR) so new contributors can see the whole process at a glance?


### PR DESCRIPTION
Cleanup of extra text generated by AI but wasn't removed when copy and pasting the docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Simplified the contributing guide’s error guidance to a single clear bullet describing a critical user-facing error.
  - Removed surrounding workflow/PR references and the quick reference checklist from that section.
  - Error guidance is now shorter and easier to scan for contributors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->