### PR TITLE
fix: Self-calling method in `http.rs`

### DIFF
--- a/crates/libtortillas/src/tracker/http.rs
+++ b/crates/libtortillas/src/tracker/http.rs
@@ -262,7 +262,7 @@ impl TrackerBase for HttpTracker {
    }
 
    fn interval(&self) -> usize {
-      self.interval()
+      self.interval.load(Ordering::Acquire)
    }
 }
 


### PR DESCRIPTION
#173 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical bug in the tracker's interval accessor that would cause the application to hang or crash when retrieving interval values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->