### PR TITLE
feat: Store & Cache messages when peer is choked

### DIFF
--- a/crates/libtortillas/src/peer/actor.rs
+++ b/crates/libtortillas/src/peer/actor.rs
@@ -390,6 +390,10 @@ impl Message<PeerMessages> for PeerActor {
          PeerMessages::Unchoke => {
             self.peer.update_last_optimistic_unchoke();
             self.peer.set_am_choked(false);
+
+            // Send all pending messages
+            self.flush_queue().await;
+            self.flush_block_requests().await;
             trace!("Peer unchoked us");
          }
          PeerMessages::Interested => {

--- a/crates/libtortillas/src/peer/actor.rs
+++ b/crates/libtortillas/src/peer/actor.rs
@@ -504,15 +504,17 @@ impl Message<PeerTell> for PeerActor {
                return;
             }
 
-            self
-               .stream
-               .send(PeerMessages::Request(
-                  index as u32,
-                  begin as u32,
-                  length as u32,
-               ))
-               .await
-               .expect("Failed to send piece request");
+            if !self.peer.am_choked() {
+               self
+                  .stream
+                  .send(PeerMessages::Request(
+                     index as u32,
+                     begin as u32,
+                     length as u32,
+                  ))
+                  .await
+                  .expect("Failed to send piece request");
+            }
             self.pending_block_requests.insert((index, begin, length));
             trace!(piece_index = index, "Sent piece request to peer");
          }

--- a/crates/libtortillas/src/peer/actor.rs
+++ b/crates/libtortillas/src/peer/actor.rs
@@ -1,5 +1,6 @@
 use std::{
    collections::HashMap,
+   collections::{HashMap, VecDeque},
    sync::{Arc, atomic::AtomicU8},
    time::Instant,
 };
@@ -39,7 +40,7 @@ pub(crate) struct PeerActor {
    supervisor: ActorRef<TorrentActor>,
 
    pending_block_requests: Arc<DashSet<(usize, usize, usize)>>,
-   pending_message_requests: Vec<PeerMessages>,
+   pending_message_requests: VecDeque<PeerMessages>,
 }
 
 impl PeerActor {
@@ -232,7 +233,7 @@ impl PeerActor {
    async fn flush_queue(&mut self) {
       let queued_messages = self.pending_message_requests.len();
 
-      while let Some(msg) = self.pending_message_requests.pop() {
+      while let Some(msg) = self.pending_message_requests.pop_back() {
          self
             .stream
             .send(msg)
@@ -304,7 +305,7 @@ impl Actor for PeerActor {
          stream,
          supervisor,
          pending_block_requests: Arc::new(DashSet::new()),
-         pending_message_requests: Vec::with_capacity(MAX_PENDING_MESSAGES),
+         pending_message_requests: VecDeque::with_capacity(MAX_PENDING_MESSAGES),
       })
    }
 

--- a/crates/libtortillas/src/peer/actor.rs
+++ b/crates/libtortillas/src/peer/actor.rs
@@ -1,5 +1,4 @@
 use std::{
-   collections::HashMap,
    collections::{HashMap, VecDeque},
    sync::{Arc, atomic::AtomicU8},
    time::Instant,
@@ -172,7 +171,7 @@ impl PeerActor {
             None,
          );
 
-         if let Err(e) = self.stream.send(message).await {
+         if let Err(e) = self.send_message(message).await {
             trace!(error = %e, piece, "Failed to send metadata request");
          }
       } else {
@@ -582,14 +581,13 @@ impl Message<PeerTell> for PeerActor {
          }
          PeerTell::HaveInfoDict(bitfield) => {
             self
-               .stream
-               .send(PeerMessages::Bitfield(bitfield))
+               .send_message(PeerMessages::Bitfield(bitfield))
                .await
                .expect("Failed to send bitfield");
             trace!("Sent bitfield to peer");
          }
          PeerTell::Have(piece) => {
-            if let Err(e) = self.stream.send(PeerMessages::Have(piece as u32)).await {
+            if let Err(e) = self.send_message(PeerMessages::Have(piece as u32)).await {
                trace!(piece_num = piece, error = %e, "Failed to send Have message to peer");
             }
          }

--- a/crates/libtortillas/src/peer/actor.rs
+++ b/crates/libtortillas/src/peer/actor.rs
@@ -231,6 +231,10 @@ impl PeerActor {
    /// the time we want the messages to be sent in their original order.
    #[instrument(skip(self), fields(peer_addr = %self.stream, peer_id = %self.peer.id.unwrap()))]
    async fn flush_queue(&mut self) {
+      if self.pending_message_requests.is_empty() {
+         return;
+      }
+
       let queued_messages = self.pending_message_requests.len();
 
       while let Some(msg) = self.pending_message_requests.pop_back() {
@@ -247,6 +251,10 @@ impl PeerActor {
    /// Flushes/resends all pending block requests to the peer.
    #[instrument(skip(self), fields(peer_addr = %self.stream, peer_id = %self.peer.id.unwrap()))]
    async fn flush_block_requests(&mut self) {
+      if self.pending_block_requests.is_empty() {
+         return;
+      }
+
       let queued_block_requests = self.pending_block_requests.len();
       let mut completed = Vec::with_capacity(queued_block_requests);
 


### PR DESCRIPTION
#178 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Outgoing peer messages and block requests are now queued when peers are choked, preserving order and limiting pending items.
  * Queues are flushed automatically when peers unchoke to resume transfers and sync pending requests.
  * Protocol message types now support hashing to improve internal message handling and tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->