### PR TITLE
feat: Request needed pieces from new peers on connection

### DIFF
--- a/crates/libtortillas/src/peer/actor.rs
+++ b/crates/libtortillas/src/peer/actor.rs
@@ -330,6 +330,11 @@ impl Actor for PeerActor {
          stream.send(PeerMessages::Bitfield(bitfield)).await?;
       }
 
+      supervisor
+         .tell(TorrentMessage::PeerReady(peer.id.unwrap()))
+         .await
+         .map_err(|e| PeerActorError::SupervisorCommunicationFailed(e.to_string()))?;
+
       Ok(Self {
          peer,
          stream,

--- a/crates/libtortillas/src/torrent/actor.rs
+++ b/crates/libtortillas/src/torrent/actor.rs
@@ -361,6 +361,7 @@ impl TorrentActor {
 
       self.next_piece += 1;
       self.bitfield.set_aliased(index, true);
+
       debug!(
          piece_index = index,
          pieces_left = piece_count.saturating_sub(index + 1),
@@ -376,7 +377,7 @@ impl TorrentActor {
             .await;
       }
 
-      if self.next_piece >= piece_count - 1 {
+      if self.next_piece >= piece_count {
          self.state = TorrentState::Seeding;
          self
             .update_trackers(TrackerUpdate::Event(Event::Completed))

--- a/crates/libtortillas/src/torrent/actor.rs
+++ b/crates/libtortillas/src/torrent/actor.rs
@@ -478,7 +478,7 @@ impl TorrentActor {
       self
          .block_map
          .get(&index)
-         .map(|block_map| block_map[block_index])
+         .and_then(|block_map| block_map.get(block_index).as_deref().copied())
          .unwrap_or(false)
    }
 

--- a/crates/libtortillas/src/torrent/actor.rs
+++ b/crates/libtortillas/src/torrent/actor.rs
@@ -261,14 +261,15 @@ impl TorrentActor {
       let block_index = offset / BLOCK_SIZE;
 
       if self.is_duplicate_block(index, block_index) {
-         self
-            .broadcast_to_peers(PeerTell::CancelPiece(index, offset, block.len()))
-            .await;
          trace!("Received duplicate piece block");
          return;
       }
 
       self.initialize_and_mark_block(index, block_index);
+
+      self
+         .broadcast_to_peers(PeerTell::CancelPiece(index, offset, block.len()))
+         .await;
 
       self.write_block_to_storage(index, offset, block).await;
 

--- a/crates/libtortillas/src/torrent/messages.rs
+++ b/crates/libtortillas/src/torrent/messages.rs
@@ -14,9 +14,7 @@ use kameo::{
 use sha1::{Digest, Sha1};
 use tracing::{info, instrument, trace, warn};
 
-use super::{
-   PieceStorageStrategy, ReadyHook, TorrentActor, TorrentExport, TorrentState, util,
-};
+use super::{PieceStorageStrategy, ReadyHook, TorrentActor, TorrentExport, TorrentState, util};
 use crate::{
    actor_request_response,
    hashes::InfoHash,
@@ -207,7 +205,7 @@ impl Message<TorrentMessage> for TorrentActor {
                   .tell(PeerTell::NeedPiece(piece_idx, block_offset, block_length))
                   .await
                   .expect("Failed to send piece request to peer");
-               trace!(peer_id = %id, piece_idx, block_offset, block_length, "Requested piece form new peer");
+               trace!(peer_id = %id, piece_idx, block_offset, block_length, "Requested piece from new peer");
             } else {
                trace!(peer_id = %id, state = ?self.state, ready = self.is_ready(), "Ignoring PeerReady: peer unknown, dead, or torrent not in download state");
             }

--- a/crates/libtortillas/src/torrent/messages.rs
+++ b/crates/libtortillas/src/torrent/messages.rs
@@ -210,7 +210,7 @@ impl Message<TorrentMessage> for TorrentActor {
                   .expect("Failed to send piece request to peer");
                trace!(peer_id = %id, piece_idx, block_offset, block_length, "Requested piece form new peer");
             } else {
-               warn!("Received peer ready message for unknown peer");
+               trace!(peer_id = %id, state = ?self.state, ready = self.is_ready(), "Ignoring PeerReady: peer unknown, dead, or torrent not in download state");
             }
          }
          TorrentMessage::IncomingPiece(index, offset, block) => {

--- a/crates/libtortillas/src/torrent/messages.rs
+++ b/crates/libtortillas/src/torrent/messages.rs
@@ -12,11 +12,10 @@ use kameo::{
    prelude::{Context, Message},
 };
 use sha1::{Digest, Sha1};
-use tokio::fs;
-use tracing::{debug, error, info, instrument, trace, warn};
+use tracing::{info, instrument, trace, warn};
 
 use super::{
-   BLOCK_SIZE, PieceStorageStrategy, ReadyHook, TorrentActor, TorrentExport, TorrentState, util,
+   PieceStorageStrategy, ReadyHook, TorrentActor, TorrentExport, TorrentState, util,
 };
 use crate::{
    actor_request_response,
@@ -25,7 +24,7 @@ use crate::{
    peer::{Peer, PeerId, PeerTell},
    protocol::stream::PeerStream,
    torrent::{PieceManagerProxy, piece_manager::PieceManager},
-   tracker::{Event, Tracker, TrackerMessage, TrackerUpdate},
+   tracker::Tracker,
 };
 
 /// For incoming from outside sources (e.g Peers, Trackers and Engine)

--- a/crates/libtortillas/src/torrent/messages.rs
+++ b/crates/libtortillas/src/torrent/messages.rs
@@ -75,6 +75,9 @@ pub(crate) enum TorrentMessage {
    ///
    /// Only should be used internally.
    ReadyHook(ReadyHook),
+
+   /// Sent after the `PeerActor::on_start` is ran
+   PeerReady(PeerId),
 }
 
 impl fmt::Debug for TorrentMessage {
@@ -191,161 +194,11 @@ impl Message<TorrentMessage> for TorrentActor {
                warn!("Received kill tracker message for unknown tracker");
             }
          }
+            } else {
          TorrentMessage::IncomingPiece(index, offset, block) => {
-            let info_dict = self
-               .info_dict()
-               .expect("Can't receive piece without info dict");
-
-            let total_length = info_dict.total_length();
-
-            let block_index = offset / BLOCK_SIZE;
-            let piece_count = info_dict.piece_count();
-
-            if let Some(block_map) = &self.block_map.get_mut(&index) {
-               self
-                  .broadcast_to_peers(PeerTell::CancelPiece(index, offset, block.len()))
-                  .await;
-               if block_map[block_index] {
-                  trace!("Received duplicate piece block");
-                  return;
-               }
-            } else {
-               let total_blocks = (info_dict.piece_length as usize).div_ceil(BLOCK_SIZE);
-               let mut vec = BitVec::with_capacity(total_blocks);
-               vec.resize(total_blocks, false);
-               self.block_map.insert(index, vec);
-            };
-
-            self
-               .block_map
-               .get_mut(&index)
-               .unwrap() // Unwrap is safe because we just inserted the block map
-               .set(block_index, true);
-
-            let block_len = block.len();
-
-            let is_piece_complete = self
-               .block_map
-               .get(&index)
-               .map(|blocks| blocks.iter().all(|b| *b))
-               .unwrap_or(false);
-
-            match &self.piece_storage {
-               PieceStorageStrategy::Disk(_) => {
-                  let path = self
-                     .get_piece_path(index)
-                     .expect("Failed to get piece path");
-                  util::write_block_to_file(path, offset, block)
-                     .await
-                     .expect("Failed to write block to file")
-               }
-               PieceStorageStrategy::InFile => {
-                  unimplemented!()
-               }
-            };
-
-            // We now have the full piece
-            if is_piece_complete {
-               let previous_blocks = self.block_map.remove(&index);
-               let cur_piece = self.next_piece;
-
-               match &self.piece_storage {
-                  PieceStorageStrategy::Disk(_) => {
-                     let path = self
-                        .get_piece_path(index)
-                        .expect("Failed to get piece path");
-                     if util::validate_piece_file(path.clone(), info_dict.pieces[index])
-                        .await
-                        .is_err()
-                     {
-                        warn!(path = %path.display(), index, "Piece file is invalid, clearing it");
-                        let path_clone = path.clone();
-
-                        // Clears the piece on a new thread
-                        tokio::spawn(async move {
-                           fs::remove_file(&path_clone).await.unwrap_or_else(|_| {
-                              error!("Failed to delete file for piece {}", &path_clone.display());
-                           });
-                        });
-                        return;
-                     }
-
-                     let data = fs::read(&path).await.unwrap().into();
-                     if let Err(err) = self.piece_manager.recv(index, data).await {
-                        warn!(?err, index, path = %path.display(), "Piece manager rejected piece; re-requesting");
-                        if let Some((_, mut blocks)) = previous_blocks {
-                           blocks.fill(false);
-                           self.block_map.insert(index, blocks);
-                        }
-                        self
-                           .broadcast_to_peers(PeerTell::NeedPiece(index, 0, BLOCK_SIZE))
-                           .await;
-                        return;
-                     }
-                  }
-                  PieceStorageStrategy::InFile => {
-                     unimplemented!()
-                  }
-               }
-
-               self.next_piece += 1;
-               self.bitfield.set_aliased(index, true);
-               debug!(
-                  piece_index = index,
-                  pieces_left = piece_count.saturating_sub(index + 1),
-                  "Piece is now complete"
-               );
-
-               // Announce to peers that we have this piece
-               self.broadcast_to_peers(PeerTell::Have(cur_piece)).await;
-
-               if let Some(total_downloaded) = self.total_bytes_downloaded() {
-                  let total_bytes_left = total_length - total_downloaded;
-                  self
-                     .update_trackers(TrackerUpdate::Left(total_bytes_left))
-                     .await;
-               }
-
-               if self.next_piece >= piece_count - 1 {
-                  // Handle end of torrenting process
-                  self.state = TorrentState::Seeding;
-
-                  // Announce to trackers that we have completed the torrent
-                  self
-                     .update_trackers(TrackerUpdate::Event(Event::Completed))
-                     .await;
-                  self.broadcast_to_trackers(TrackerMessage::Announce).await;
-
-                  info!("Torrenting process completed, switching to seeding mode");
-               } else {
-                  self
-                     .broadcast_to_peers(PeerTell::NeedPiece(self.next_piece, 0, BLOCK_SIZE))
-                     .await;
-               }
-            } else {
-               // We need more blocks
-               // Requests the next block at the next offset
-               let offset = offset + block_len;
-
-               // Check if we're overflowing the piece, this is only when we're requesting the
-               // last block. This happens because if a piece is lets say 100 bytes, and we
-               // request 40 bytes per block, when we're on piece 2, we'll
-               // overflow and request 120 bytes instargo ad of 100. This checks if we're
-               // overflowing and if so, we'll request the remaining bytes of
-               // the piece
-               let is_overflowing = offset + BLOCK_SIZE > info_dict.piece_length as usize;
-               let next_block_len = if is_overflowing {
-                  info_dict.piece_length as usize - offset
-               } else {
-                  BLOCK_SIZE
-               };
-
-               self
-                  .broadcast_to_peers(PeerTell::NeedPiece(index, offset, next_block_len))
-                  .await;
-               trace!(piece = index, "Requested next block");
-            };
+            self.incoming_piece(index, offset, block).await
          }
+
          TorrentMessage::PieceStorage(strategy) => {
             if !self.is_empty() {
                // Intentional panic because this is unintended behavior


### PR DESCRIPTION
#179

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Peer-ready signaling so peers notify the torrent controller when ready, triggering next-block requests.
  * High-level incoming-piece flow and a block-scheduling helper to orchestrate receiving, deduplicating, storing, validating, and completing pieces.

* **Refactor**
  * Centralized piece-transfer pipeline: incoming piece handling delegated to the new flow for clearer sequencing and reduced inline complexity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->