### PR TITLE
fix: enforce BEP 3 request block size limits

### DIFF
--- a/crates/libtortillas/src/peer/actor.rs
+++ b/crates/libtortillas/src/peer/actor.rs
@@ -17,6 +17,7 @@ use kameo::{
 };
 use messages::{ExtendedMessage, ExtendedMessageType, PeerMessages};
 use stream::{PeerSend, PeerStream};
+use tokio::io::AsyncWriteExt;
 use tracing::{Span, debug, info, instrument, trace, warn};
 
 use crate::{
@@ -24,7 +25,7 @@ use crate::{
    hashes::InfoHash,
    peer::Peer,
    protocol::{stream::PeerRecv, *},
-   torrent::{self, TorrentActor},
+   torrent::{self, BLOCK_SIZE, TorrentActor},
 };
 
 const MAX_PENDING_MESSAGES: usize = 8;
@@ -512,6 +513,16 @@ impl Message<PeerMessages> for PeerActor {
                piece_index = index,
                offset, length, "Peer requested piece data"
             );
+
+            if length == 0 || length as usize > BLOCK_SIZE {
+               warn!(
+                  piece_index = index,
+                  offset, length, "Peer sent invalid request; closing connection"
+               );
+               let _ = self.stream.shutdown().await;
+               return;
+            }
+
             let (index, offset, data) = self
                .supervisor
                .ask(torrent::commands::RequestPiece {

--- a/crates/libtortillas/src/torrent/messages.rs
+++ b/crates/libtortillas/src/torrent/messages.rs
@@ -313,6 +313,14 @@ pub(crate) mod commands {
             return (index, offset, None);
          };
 
+         if length == 0 {
+            warn!(
+               index,
+               offset, length, "Peer requested block with zero length"
+            );
+            return (index, offset, None);
+         }
+
          if length > BLOCK_SIZE {
             warn!(
                index,


### PR DESCRIPTION
Closes #203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for peer requests to ensure request sizes are non-zero and do not exceed maximum block limits. Invalid requests are now properly rejected with appropriate logging and peer disconnection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/artrixdotdev/tortillas/pull/214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->