### PR TITLE
refactor: runtime defaults into settings

### DIFF
--- a/crates/libtortillas/src/engine/actor.rs
+++ b/crates/libtortillas/src/engine/actor.rs
@@ -19,6 +19,7 @@ use crate::{
    hashes::InfoHash,
    peer::PeerId,
    protocol::stream::PeerStream,
+   settings::Settings,
    torrent::{PieceStorageStrategy, TorrentActor},
    tracker::udp::UdpServer,
 };
@@ -51,13 +52,8 @@ pub struct EngineActor {
 
    pub(crate) default_piece_storage_strategy: PieceStorageStrategy,
 
-   /// Mailbox size for each torrent instance
-   pub(crate) mailbox_size: usize,
-
-   /// If we autostart torrents
-   pub(crate) autostart: Option<bool>,
-   /// How many peers we need to have before we start downloading
-   pub(crate) sufficient_peers: Option<usize>,
+   /// Runtime behavior settings shared with torrent, peer, and tracker actors.
+   pub(crate) settings: Settings,
 
    pub(crate) default_base_path: Option<PathBuf>,
 }
@@ -96,21 +92,8 @@ pub struct EngineActorArgs {
    /// managed by this engine.
    pub piece_storage_strategy: PieceStorageStrategy,
 
-   /// Mailbox size for each torrent instance.
-   ///
-   /// Defaults to 64 if not provided. If set to 0, the mailbox will be
-   /// unbounded.
-   pub mailbox_size: Option<usize>,
-
-   /// Whether to automatically start torrents when they become ready.
-   ///
-   /// If not provided, defaults to `None` (use engine-level default).
-   pub autostart: Option<bool>,
-
-   /// Minimum number of peers required before starting download.
-   ///
-   /// If not provided, defaults to `None` (use engine-level default).
-   pub sufficient_peers: Option<usize>,
+   /// Runtime behavior settings.
+   pub settings: Settings,
 
    /// Default base path for torrent downloads.
    ///
@@ -144,23 +127,24 @@ impl Actor for EngineActor {
          udp_addr,
          peer_id,
          piece_storage_strategy,
-         mailbox_size,
-         autostart,
-         sufficient_peers,
+         settings,
          default_base_path,
       } = args;
 
-      let tcp_addr = tcp_addr.unwrap_or_else(|| SocketAddr::from(([0, 0, 0, 0], 0)));
-      // Should this be port 6881?
-      let utp_addr = utp_addr.unwrap_or_else(|| SocketAddr::from(([0, 0, 0, 0], 0)));
-      let udp_addr = udp_addr.unwrap_or_else(|| SocketAddr::from(([0, 0, 0, 0], 0)));
+      let tcp_addr = tcp_addr.unwrap_or(settings.engine.tcp_addr);
+      let utp_addr = utp_addr.unwrap_or(settings.engine.utp_addr);
+      let udp_addr = udp_addr.unwrap_or(settings.engine.udp_addr);
       let tcp_socket = TcpListener::bind(tcp_addr)
          .await
          .map_err(|e| EngineError::NetworkSetupFailed(format!("tcp bind {tcp_addr}: {e}")))?;
       let utp_socket = UtpSocketUdp::new_udp(utp_addr)
          .await
          .map_err(|e| EngineError::NetworkSetupFailed(format!("utp bind {utp_addr}: {e}")))?;
-      let udp_server = UdpServer::new(Some(udp_addr)).await;
+      let udp_server = UdpServer::new_with_receive_buffer_size(
+         Some(udp_addr),
+         settings.tracker.udp_receive_buffer_size,
+      )
+      .await;
 
       let peer_id = peer_id.unwrap_or_default();
 
@@ -172,9 +156,7 @@ impl Actor for EngineActor {
          peer_id,
          actor_ref,
          default_piece_storage_strategy: piece_storage_strategy,
-         mailbox_size: mailbox_size.unwrap_or(64),
-         autostart,
-         sufficient_peers,
+         settings,
          default_base_path,
       })
    }

--- a/crates/libtortillas/src/engine/actor.rs
+++ b/crates/libtortillas/src/engine/actor.rs
@@ -144,7 +144,8 @@ impl Actor for EngineActor {
          Some(udp_addr),
          settings.tracker.udp_receive_buffer_size,
       )
-      .await;
+      .await
+      .map_err(|e| EngineError::NetworkSetupFailed(format!("udp bind {udp_addr}: {e}")))?;
 
       let peer_id = peer_id.unwrap_or_default();
 

--- a/crates/libtortillas/src/engine/messages.rs
+++ b/crates/libtortillas/src/engine/messages.rs
@@ -118,8 +118,8 @@ pub(crate) mod commands {
          )
          .restart_policy(RestartPolicy::Permanent)
          .restart_limit(
-            self.settings.engine.torrent_restart_limit,
-            self.settings.engine.torrent_restart_period,
+            self.settings.engine.torrent_restart.limit,
+            self.settings.engine.torrent_restart.period,
          )
          .spawn_with_mailbox(match self.settings.engine.torrent_mailbox_size {
             0 => {

--- a/crates/libtortillas/src/engine/messages.rs
+++ b/crates/libtortillas/src/engine/messages.rs
@@ -1,6 +1,6 @@
 use futures::future::try_join_all;
 use kameo::{actor::Spawn, mailbox, messages, prelude::ActorRef, supervision::RestartPolicy};
-use tokio::time::{Duration, timeout};
+use tokio::time::timeout;
 use tracing::{error, warn};
 
 use super::{EngineActor, EngineExport};
@@ -11,8 +11,6 @@ use crate::{
    protocol::stream::{PeerStream, validate_handshake_protocol},
    torrent::{self, TorrentActor, TorrentActorArgs, TorrentState},
 };
-
-const INCOMING_PEER_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub(crate) mod commands {
    use anyhow::anyhow;
@@ -25,19 +23,15 @@ pub(crate) mod commands {
       /// handshaked nor verified at this point.
       #[message]
       pub(crate) async fn incoming_peer(&mut self, mut stream: PeerStream) {
-         let handshake = match timeout(
-            INCOMING_PEER_HANDSHAKE_TIMEOUT,
-            stream.recv_handshake_message(),
-         )
-         .await
-         {
+         let handshake_timeout = self.settings.engine.incoming_peer_handshake_timeout;
+         let handshake = match timeout(handshake_timeout, stream.recv_handshake_message()).await {
             Ok(Ok(handshake)) => handshake,
             Ok(Err(err)) => {
                warn!(error = %err, %stream, "Failed to read incoming peer handshake");
                return;
             }
             Err(_) => {
-               warn!(%stream, timeout = ?INCOMING_PEER_HANDSHAKE_TIMEOUT, "Timed out reading incoming peer handshake");
+               warn!(%stream, timeout = ?handshake_timeout, "Timed out reading incoming peer handshake");
                return;
             }
          };
@@ -116,14 +110,18 @@ pub(crate) mod commands {
                tracker_server: self.udp_server.clone(),
                primary_addr: None,
                piece_storage: self.default_piece_storage_strategy.clone(),
-               autostart: self.autostart,
-               sufficient_peers: self.sufficient_peers,
+               autostart: None,
+               sufficient_peers: None,
                base_path: self.default_base_path.clone(),
+               settings: self.settings.clone(),
             },
          )
          .restart_policy(RestartPolicy::Permanent)
-         .restart_limit(3, Duration::from_secs(60))
-         .spawn_with_mailbox(match self.mailbox_size {
+         .restart_limit(
+            self.settings.engine.torrent_restart_limit,
+            self.settings.engine.torrent_restart_period,
+         )
+         .spawn_with_mailbox(match self.settings.engine.torrent_mailbox_size {
             0 => {
                warn!(
                   ?info_hash,

--- a/crates/libtortillas/src/engine/mod.rs
+++ b/crates/libtortillas/src/engine/mod.rs
@@ -51,6 +51,7 @@ use crate::{
    errors::EngineError,
    metainfo::{MetaInfo, TorrentFile},
    peer::PeerId,
+   settings::Settings,
    torrent::{PieceStorageStrategy, Torrent, TorrentExport},
 };
 
@@ -104,6 +105,9 @@ impl Engine {
       /// Strategy for storing pieces of the torrent.
       #[builder(default)]
       piece_storage_strategy: PieceStorageStrategy,
+      /// Runtime behavior settings for engine, torrent, peer, and tracker
+      /// actors.
+      settings: Option<Settings>,
       /// The mailbox size for each torrent instance.
       ///
       /// In simple terms, this is the number of messages that each torrent
@@ -134,6 +138,17 @@ impl Engine {
       #[builder(into)]
       output_path: Option<PathBuf>,
    ) -> Self {
+      let mut settings = settings.unwrap_or_default();
+      if let Some(mailbox_size) = mailbox_size {
+         settings.engine.torrent_mailbox_size = mailbox_size;
+      }
+      if let Some(autostart) = autostart {
+         settings.torrent.autostart = autostart;
+      }
+      if let Some(sufficient_peers) = sufficient_peers {
+         settings.torrent.sufficient_peers = sufficient_peers;
+      }
+
       let output_path = match output_path {
          Some(path) => {
             if path.is_absolute() {
@@ -153,9 +168,7 @@ impl Engine {
          udp_addr,
          peer_id: Some(custom_id),
          piece_storage_strategy,
-         mailbox_size,
-         autostart,
-         sufficient_peers,
+         settings,
          default_base_path: Some(output_path),
       };
 

--- a/crates/libtortillas/src/engine/mod.rs
+++ b/crates/libtortillas/src/engine/mod.rs
@@ -114,23 +114,42 @@ impl Engine {
       /// instance can have in queue.
       ///
       /// If `Some(0)` is provided, the mailbox will be unbounded (no limit).
-      /// If `None` is provided, a sensible default is used.
+      /// If `Some(_)` is provided, it overrides
+      /// [`Settings::engine.
+      /// torrent_mailbox_size`](crate::settings::EngineSettings::torrent_mailbox_size).
+      /// If `None` is provided, the supplied [`Settings`] value is
+      /// preserved.
       ///
       /// Higher values increase memory usage but reduce sender backpressure
       /// when the mailbox is busy, which can improve throughput. Lower values
       /// do the inverse.
       ///
-      /// Default: `64` when `None` is provided.
+      /// Default: `64` through [`Settings::default`] when no custom settings
+      /// are supplied.
       mailbox_size: Option<usize>,
       /// If we autostart torrents as soon as we have [`Self::sufficient_peers`]
       /// peers connected.
-      /// Default: `true`
+      ///
+      /// If `Some(_)` is provided, it overrides
+      /// [`Settings::torrent.
+      /// autostart`](crate::settings::TorrentSettings::autostart).
+      /// If `None` is provided, the supplied [`Settings`] value is preserved.
+      ///
+      /// Default: `true` through [`Settings::default`] when no custom settings
+      /// are supplied.
       autostart: Option<bool>,
       /// How many peers we need to have before we start downloading.
       ///
       /// Is ignored if [`Self::autostart`] is `false`.
       ///
-      /// Default: `6`
+      /// If `Some(_)` is provided, it overrides
+      /// [`Settings::torrent.
+      /// sufficient_peers`](crate::settings::TorrentSettings::sufficient_peers).
+      /// If `None` is provided, the supplied [`Settings`] value is
+      /// preserved.
+      ///
+      /// Default: `6` through [`Settings::default`] when no custom settings
+      /// are supplied.
       sufficient_peers: Option<usize>,
       /// Default base path for torrents
       ///

--- a/crates/libtortillas/src/lib.rs
+++ b/crates/libtortillas/src/lib.rs
@@ -5,6 +5,7 @@ pub mod metainfo;
 pub mod peer;
 pub mod pieces;
 pub mod protocol;
+pub mod settings;
 pub mod torrent;
 pub mod tracker;
 
@@ -119,6 +120,7 @@ pub mod prelude {
       hashes::InfoHash,
       metainfo::*,
       peer::{Peer, PeerId},
+      settings::*,
       torrent::*,
       tracker::Tracker,
    };

--- a/crates/libtortillas/src/lib.rs
+++ b/crates/libtortillas/src/lib.rs
@@ -93,7 +93,7 @@ pub(crate) mod testing {
    }
 
    pub(crate) async fn udp_server() -> UdpServer {
-      UdpServer::new(None).await
+      UdpServer::new(None).await.unwrap()
    }
 
    pub(crate) fn init_tracing() {

--- a/crates/libtortillas/src/peer/actor.rs
+++ b/crates/libtortillas/src/peer/actor.rs
@@ -1,7 +1,7 @@
 use std::{
    collections::{HashMap, HashSet, VecDeque},
    sync::{Arc, atomic::AtomicU8},
-   time::Instant,
+   time::{Duration, Instant},
 };
 
 use anyhow::Context;
@@ -438,47 +438,66 @@ impl Actor for PeerActor {
    async fn next(
       &mut self, actor_ref: WeakActorRef<Self>, mailbox_rx: &mut MailboxReceiver<Self>,
    ) -> Result<Option<Signal<Self>>, Self::Error> {
-      // Send a BEP 3 keepalive after two minutes of silence, then disconnect
-      // only if the peer remains silent for another keepalive interval.
-      let last_message = self
-         .peer
-         .last_message_received()
-         .unwrap_or_else(Instant::now)
-         .elapsed();
-
-      if last_message > self.settings.keepalive_timeout
-         && let Err(err) = self
-            .stream
-            .send(PeerMessages::KeepAlive)
-            .await
-            .context("Peer connection closed")
-      {
-         warn!(error = %err, "Failed to send keep alive message to peer");
-         return Ok(Some(Signal::Stop));
-      }
-
-      if last_message > self.settings.disconnect_timeout {
-         let id = self.peer.id.expect("Peer ID should exist");
-         if let Err(err) = self
-            .supervisor
-            .tell(torrent::commands::KillPeer { id })
-            .await
-         {
-            warn!(error = %err, "Failed to tell supervisor to kill peer");
-         }
-         return Ok(Some(Signal::Stop));
-         // The supervisor will kill the peer manually, no need to do it
-         // ourselves.
-      }
-
       loop {
+         // Send a BEP 3 keepalive after an idle period, then disconnect only if
+         // the peer remains silent until the disconnect deadline.
+         let last_received = self
+            .peer
+            .last_message_received()
+            .unwrap_or_else(Instant::now);
+         let idle = last_received.elapsed();
+
+         if idle >= self.settings.disconnect_timeout {
+            let id = self.peer.id.expect("Peer ID should exist");
+            if let Err(err) = self
+               .supervisor
+               .tell(torrent::commands::KillPeer { id })
+               .await
+            {
+               warn!(error = %err, "Failed to tell supervisor to kill peer");
+            }
+            // The supervisor will kill the peer manually, no need to do it
+            // ourselves.
+            return Ok(Some(Signal::Stop));
+         }
+
+         let keepalive_sent = self
+            .peer
+            .last_message_sent()
+            .is_some_and(|last_sent| last_sent >= last_received);
+         if idle >= self.settings.keepalive_timeout && !keepalive_sent {
+            if let Err(err) = self
+               .stream
+               .send(PeerMessages::KeepAlive)
+               .await
+               .context("Peer connection closed")
+            {
+               warn!(error = %err, "Failed to send keep alive message to peer");
+               return Ok(Some(Signal::Stop));
+            }
+            self.peer.update_last_message_sent();
+         }
+
+         let next_idle_deadline = if keepalive_sent || idle >= self.settings.keepalive_timeout {
+            self.settings.disconnect_timeout
+         } else {
+            self
+               .settings
+               .keepalive_timeout
+               .min(self.settings.disconnect_timeout)
+         };
+         let next_idle_check = next_idle_deadline
+            .saturating_sub(idle)
+            .max(Duration::from_millis(1));
+
          tokio::select! {
             signal = mailbox_rx.recv() => return Ok(signal),
             msg = self.stream.recv() => {
                if let Some(signal) = self.check_message_signal(actor_ref.clone(), msg) {
                   return Ok(Some(signal));
                }
-            }
+            },
+            _ = tokio::time::sleep(next_idle_check) => {}
          }
       }
    }

--- a/crates/libtortillas/src/peer/actor.rs
+++ b/crates/libtortillas/src/peer/actor.rs
@@ -25,13 +25,9 @@ use crate::{
    hashes::InfoHash,
    peer::{Peer, PeerId},
    protocol::{stream::PeerRecv, *},
+   settings::PeerSettings,
    torrent::{self, BLOCK_SIZE, TorrentActor},
 };
-
-const MAX_PENDING_MESSAGES: usize = 8;
-
-const PEER_KEEPALIVE_TIMEOUT: u64 = 120;
-const PEER_DISCONNECT_TIMEOUT: u64 = 240;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct PeerStats {
@@ -73,6 +69,7 @@ pub(crate) struct PeerActor {
    pending_block_requests: HashSet<(usize, usize, usize)>,
    pending_message_requests: VecDeque<PeerMessages>,
    last_rate_sample: RateSample,
+   settings: PeerSettings,
 }
 
 impl PeerActor {
@@ -374,13 +371,19 @@ impl PeerActor {
 }
 
 impl Actor for PeerActor {
-   type Args = (Peer, PeerStream, ActorRef<TorrentActor>, InfoHash);
+   type Args = (
+      Peer,
+      PeerStream,
+      ActorRef<TorrentActor>,
+      InfoHash,
+      PeerSettings,
+   );
    type Error = PeerActorError;
 
    /// At this point, the peer has already been handshaked with. No other
    /// messages have been sent or received from the peer.
    async fn on_start(args: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
-      let (peer, mut stream, supervisor, info_hash) = args;
+      let (peer, mut stream, supervisor, info_hash, settings) = args;
 
       info!(peer_id = %peer.id.unwrap(),  peer_addr = %stream, torrent_id = %info_hash, "Peer connected");
       let bitfield = match supervisor.ask(torrent::commands::GetBitfield).await {
@@ -410,7 +413,8 @@ impl Actor for PeerActor {
          stream,
          supervisor,
          pending_block_requests: HashSet::new(),
-         pending_message_requests: VecDeque::with_capacity(MAX_PENDING_MESSAGES),
+         pending_message_requests: VecDeque::with_capacity(settings.pending_message_capacity),
+         settings,
       })
    }
 
@@ -440,10 +444,9 @@ impl Actor for PeerActor {
          .peer
          .last_message_received()
          .unwrap_or_else(Instant::now)
-         .elapsed()
-         .as_secs();
+         .elapsed();
 
-      if last_message > PEER_KEEPALIVE_TIMEOUT
+      if last_message > self.settings.keepalive_timeout
          && let Err(err) = self
             .stream
             .send(PeerMessages::KeepAlive)
@@ -454,7 +457,7 @@ impl Actor for PeerActor {
          return Ok(Some(Signal::Stop));
       }
 
-      if last_message > PEER_DISCONNECT_TIMEOUT {
+      if last_message > self.settings.disconnect_timeout {
          let id = self.peer.id.expect("Peer ID should exist");
          if let Err(err) = self
             .supervisor

--- a/crates/libtortillas/src/settings.rs
+++ b/crates/libtortillas/src/settings.rs
@@ -13,7 +13,6 @@ pub struct Settings {
    pub tracker: TrackerSettings,
 }
 
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EngineSettings {
    pub tcp_addr: SocketAddr,

--- a/crates/libtortillas/src/settings.rs
+++ b/crates/libtortillas/src/settings.rs
@@ -1,0 +1,158 @@
+use std::{net::SocketAddr, time::Duration};
+
+/// Runtime settings for client-tunable behavior.
+///
+/// Wire-format constants and BEP-mandated protocol values intentionally remain
+/// near the protocol code that depends on them.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Settings {
+   pub engine: EngineSettings,
+   pub torrent: TorrentSettings,
+   pub peer: PeerSettings,
+   pub tracker: TrackerSettings,
+}
+
+impl Default for Settings {
+   fn default() -> Self {
+      Self {
+         engine: EngineSettings::default(),
+         torrent: TorrentSettings::default(),
+         peer: PeerSettings::default(),
+         tracker: TrackerSettings::default(),
+      }
+   }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EngineSettings {
+   pub tcp_addr: SocketAddr,
+   pub utp_addr: SocketAddr,
+   pub udp_addr: SocketAddr,
+   pub torrent_mailbox_size: usize,
+   pub incoming_peer_handshake_timeout: Duration,
+   pub torrent_restart_limit: u32,
+   pub torrent_restart_period: Duration,
+}
+
+impl Default for EngineSettings {
+   fn default() -> Self {
+      Self {
+         tcp_addr: SocketAddr::from(([0, 0, 0, 0], 0)),
+         utp_addr: SocketAddr::from(([0, 0, 0, 0], 0)),
+         udp_addr: SocketAddr::from(([0, 0, 0, 0], 0)),
+         torrent_mailbox_size: 64,
+         incoming_peer_handshake_timeout: Duration::from_secs(10),
+         torrent_restart_limit: 3,
+         torrent_restart_period: Duration::from_secs(60),
+      }
+   }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TorrentSettings {
+   pub autostart: bool,
+   pub sufficient_peers: usize,
+   pub initial_peer_request_window: usize,
+   pub max_in_flight_per_peer: usize,
+   pub peer_mailbox_size: usize,
+   pub peer_broadcast_concurrency: usize,
+   pub tracker_broadcast_concurrency: usize,
+   pub scheduler_restart_limit: u32,
+   pub scheduler_restart_period: Duration,
+   pub tracker_restart_limit: u32,
+   pub tracker_restart_period: Duration,
+   pub piece_store_restart_limit: u32,
+   pub piece_store_restart_period: Duration,
+   pub upload_slots: usize,
+   pub rechoke_interval: Duration,
+   pub optimistic_unchoke_rounds: usize,
+   pub peer_stats_concurrency: usize,
+   pub peer_stats_timeout: Duration,
+}
+
+impl Default for TorrentSettings {
+   fn default() -> Self {
+      Self {
+         autostart: true,
+         sufficient_peers: 6,
+         initial_peer_request_window: 32,
+         max_in_flight_per_peer: 32,
+         peer_mailbox_size: 120,
+         peer_broadcast_concurrency: 32,
+         tracker_broadcast_concurrency: 8,
+         scheduler_restart_limit: 3,
+         scheduler_restart_period: Duration::from_secs(10),
+         tracker_restart_limit: 3,
+         tracker_restart_period: Duration::from_secs(60),
+         piece_store_restart_limit: 3,
+         piece_store_restart_period: Duration::from_secs(10),
+         upload_slots: 4,
+         rechoke_interval: Duration::from_secs(10),
+         optimistic_unchoke_rounds: 3,
+         peer_stats_concurrency: 32,
+         peer_stats_timeout: Duration::from_millis(250),
+      }
+   }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PeerSettings {
+   pub pending_message_capacity: usize,
+   pub keepalive_timeout: Duration,
+   pub disconnect_timeout: Duration,
+}
+
+impl Default for PeerSettings {
+   fn default() -> Self {
+      Self {
+         pending_message_capacity: 8,
+         keepalive_timeout: Duration::from_secs(120),
+         disconnect_timeout: Duration::from_secs(240),
+      }
+   }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TrackerSettings {
+   pub default_peer_addr: SocketAddr,
+   pub initial_announce_delay: Duration,
+   pub minimum_announce_interval: Duration,
+   pub stop_timeout: Duration,
+   pub http_stop_timeout: Duration,
+   pub http_compact_response: bool,
+   pub udp_connect_timeout: Duration,
+   pub udp_message_timeout: Duration,
+   pub udp_receive_buffer_size: usize,
+   pub udp_retry_initial_delay: Duration,
+   pub udp_retry_factor: u64,
+   pub udp_retry_max_delay: Duration,
+   pub udp_retry_attempts: usize,
+   pub udp_connection_id_retry_attempts: usize,
+   pub udp_announce_ip_address: u32,
+   pub udp_announce_key: u32,
+   pub udp_num_want: i32,
+}
+
+impl Default for TrackerSettings {
+   fn default() -> Self {
+      Self {
+         default_peer_addr: SocketAddr::from(([0, 0, 0, 0], 6881)),
+         initial_announce_delay: Duration::ZERO,
+         minimum_announce_interval: Duration::from_secs(1),
+         stop_timeout: Duration::from_secs(5),
+         http_stop_timeout: Duration::from_secs(3),
+         http_compact_response: false,
+         udp_connect_timeout: Duration::from_secs(3),
+         udp_message_timeout: Duration::from_millis(300),
+         udp_receive_buffer_size: 8192,
+         udp_retry_initial_delay: Duration::from_secs(15),
+         udp_retry_factor: 2,
+         udp_retry_max_delay: Duration::from_secs(3840),
+         udp_retry_attempts: 8,
+         udp_connection_id_retry_attempts: 2,
+         udp_announce_ip_address: 0,
+         udp_announce_key: 0,
+         udp_num_want: -1,
+      }
+   }
+}

--- a/crates/libtortillas/src/settings.rs
+++ b/crates/libtortillas/src/settings.rs
@@ -5,6 +5,7 @@ use std::{net::SocketAddr, time::Duration};
 /// Wire-format constants and BEP-mandated protocol values intentionally remain
 /// near the protocol code that depends on them.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Default)]
 pub struct Settings {
    pub engine: EngineSettings,
    pub torrent: TorrentSettings,
@@ -12,16 +13,6 @@ pub struct Settings {
    pub tracker: TrackerSettings,
 }
 
-impl Default for Settings {
-   fn default() -> Self {
-      Self {
-         engine: EngineSettings::default(),
-         torrent: TorrentSettings::default(),
-         peer: PeerSettings::default(),
-         tracker: TrackerSettings::default(),
-      }
-   }
-}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EngineSettings {

--- a/crates/libtortillas/src/settings.rs
+++ b/crates/libtortillas/src/settings.rs
@@ -4,24 +4,47 @@ use std::{net::SocketAddr, time::Duration};
 ///
 /// Wire-format constants and BEP-mandated protocol values intentionally remain
 /// near the protocol code that depends on them.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[derive(Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Settings {
+   /// Engine actor and incoming socket settings.
    pub engine: EngineSettings,
+   /// Per-torrent actor settings.
    pub torrent: TorrentSettings,
+   /// Per-peer actor settings.
    pub peer: PeerSettings,
+   /// Tracker actor and tracker protocol settings.
    pub tracker: TrackerSettings,
+}
+
+/// Restart supervision settings for actors.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RestartPolicySettings {
+   /// Number of restarts allowed within [`Self::period`].
+   pub limit: u32,
+   /// Time window used by the restart limit.
+   pub period: Duration,
+}
+
+impl RestartPolicySettings {
+   pub fn new(limit: u32, period: Duration) -> Self {
+      Self { limit, period }
+   }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EngineSettings {
+   /// Default TCP bind address for incoming peer connections.
    pub tcp_addr: SocketAddr,
+   /// Default uTP bind address for incoming peer connections.
    pub utp_addr: SocketAddr,
+   /// Default UDP bind address for tracker traffic.
    pub udp_addr: SocketAddr,
+   /// Torrent actor mailbox size. `0` means unbounded.
    pub torrent_mailbox_size: usize,
+   /// Maximum time to wait for an incoming peer handshake.
    pub incoming_peer_handshake_timeout: Duration,
-   pub torrent_restart_limit: u32,
-   pub torrent_restart_period: Duration,
+   /// Restart supervision policy for torrent actors.
+   pub torrent_restart: RestartPolicySettings,
 }
 
 impl Default for EngineSettings {
@@ -32,31 +55,43 @@ impl Default for EngineSettings {
          udp_addr: SocketAddr::from(([0, 0, 0, 0], 0)),
          torrent_mailbox_size: 64,
          incoming_peer_handshake_timeout: Duration::from_secs(10),
-         torrent_restart_limit: 3,
-         torrent_restart_period: Duration::from_secs(60),
+         torrent_restart: RestartPolicySettings::new(3, Duration::from_secs(60)),
       }
    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TorrentSettings {
+   /// Start downloading automatically once the torrent is ready.
    pub autostart: bool,
+   /// Minimum connected peers required before a torrent is ready to start.
    pub sufficient_peers: usize,
+   /// Initial number of block requests sent to each peer when downloading
+   /// starts.
    pub initial_peer_request_window: usize,
+   /// Maximum in-flight block requests filled for a ready peer.
    pub max_in_flight_per_peer: usize,
+   /// Peer actor mailbox size. `0` means unbounded.
    pub peer_mailbox_size: usize,
+   /// Maximum concurrent sends when broadcasting a message to peers.
    pub peer_broadcast_concurrency: usize,
+   /// Maximum concurrent sends when broadcasting a message to trackers.
    pub tracker_broadcast_concurrency: usize,
-   pub scheduler_restart_limit: u32,
-   pub scheduler_restart_period: Duration,
-   pub tracker_restart_limit: u32,
-   pub tracker_restart_period: Duration,
-   pub piece_store_restart_limit: u32,
-   pub piece_store_restart_period: Duration,
+   /// Restart supervision policy for scheduler actors.
+   pub scheduler_restart: RestartPolicySettings,
+   /// Restart supervision policy for tracker actors.
+   pub tracker_restart: RestartPolicySettings,
+   /// Restart supervision policy for piece-store actors.
+   pub piece_store_restart: RestartPolicySettings,
+   /// Number of upload slots used by the choking scheduler.
    pub upload_slots: usize,
+   /// Time between choking scheduler recalculations.
    pub rechoke_interval: Duration,
+   /// Rechoke rounds before rotating the optimistic unchoke candidate.
    pub optimistic_unchoke_rounds: usize,
+   /// Maximum concurrent peer stats requests during rechoke.
    pub peer_stats_concurrency: usize,
+   /// Maximum time to wait for a peer stats response.
    pub peer_stats_timeout: Duration,
 }
 
@@ -70,12 +105,9 @@ impl Default for TorrentSettings {
          peer_mailbox_size: 120,
          peer_broadcast_concurrency: 32,
          tracker_broadcast_concurrency: 8,
-         scheduler_restart_limit: 3,
-         scheduler_restart_period: Duration::from_secs(10),
-         tracker_restart_limit: 3,
-         tracker_restart_period: Duration::from_secs(60),
-         piece_store_restart_limit: 3,
-         piece_store_restart_period: Duration::from_secs(10),
+         scheduler_restart: RestartPolicySettings::new(3, Duration::from_secs(10)),
+         tracker_restart: RestartPolicySettings::new(3, Duration::from_secs(60)),
+         piece_store_restart: RestartPolicySettings::new(3, Duration::from_secs(10)),
          upload_slots: 4,
          rechoke_interval: Duration::from_secs(10),
          optimistic_unchoke_rounds: 3,
@@ -87,8 +119,11 @@ impl Default for TorrentSettings {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PeerSettings {
+   /// Initial capacity for queued non-block peer messages.
    pub pending_message_capacity: usize,
+   /// Idle time since the last received message before sending a keepalive.
    pub keepalive_timeout: Duration,
+   /// Idle time since the last received message before disconnecting a peer.
    pub disconnect_timeout: Duration,
 }
 
@@ -104,22 +139,45 @@ impl Default for PeerSettings {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TrackerSettings {
+   /// Peer address sent to trackers when no explicit address is available.
    pub default_peer_addr: SocketAddr,
+   /// Delay before the tracker actor's first announce attempt.
    pub initial_announce_delay: Duration,
+   /// Lower bound for scheduled tracker announce delays.
    pub minimum_announce_interval: Duration,
+   /// Upper bound for scheduled tracker announce delays.
+   pub maximum_announce_interval: Duration,
+   /// Delay used when a tracker has not supplied a usable announce interval.
+   pub fallback_announce_interval: Duration,
+   /// Maximum time the tracker actor waits for tracker shutdown.
    pub stop_timeout: Duration,
+   /// Maximum time an HTTP tracker waits for its final stopped announce.
    pub http_stop_timeout: Duration,
+   /// Whether HTTP trackers request compact peer responses.
    pub http_compact_response: bool,
+   /// Maximum time allowed for a UDP tracker connect exchange.
    pub udp_connect_timeout: Duration,
+   /// Maximum time allowed for one UDP tracker response.
    pub udp_message_timeout: Duration,
+   /// Receive buffer size for the shared UDP tracker socket, in bytes.
    pub udp_receive_buffer_size: usize,
+   /// Initial delay for UDP tracker exponential backoff.
    pub udp_retry_initial_delay: Duration,
+   /// Multiplication factor for UDP tracker exponential backoff.
    pub udp_retry_factor: u64,
+   /// Maximum delay for UDP tracker exponential backoff.
    pub udp_retry_max_delay: Duration,
+   /// Number of UDP tracker retry attempts per request.
    pub udp_retry_attempts: usize,
+   /// Attempts to reconnect and retry when a UDP tracker rejects a connection
+   /// ID.
    pub udp_connection_id_retry_attempts: usize,
+   /// Raw IPv4 address field for UDP announces. `0` lets the tracker infer it.
    pub udp_announce_ip_address: u32,
+   /// Raw UDP announce key field. `0` preserves the current generated-none
+   /// behavior.
    pub udp_announce_key: u32,
+   /// UDP announce `num_want` field. `-1` asks the tracker to use its default.
    pub udp_num_want: i32,
 }
 
@@ -129,6 +187,8 @@ impl Default for TrackerSettings {
          default_peer_addr: SocketAddr::from(([0, 0, 0, 0], 6881)),
          initial_announce_delay: Duration::ZERO,
          minimum_announce_interval: Duration::from_secs(1),
+         maximum_announce_interval: Duration::from_secs(3600),
+         fallback_announce_interval: Duration::from_secs(60),
          stop_timeout: Duration::from_secs(5),
          http_stop_timeout: Duration::from_secs(3),
          http_compact_response: false,

--- a/crates/libtortillas/src/torrent/actor.rs
+++ b/crates/libtortillas/src/torrent/actor.rs
@@ -474,8 +474,8 @@ impl Actor for TorrentActor {
       let scheduler = Scheduler::supervise_with(&us, Scheduler::new)
          .restart_policy(RestartPolicy::Permanent)
          .restart_limit(
-            settings.torrent.scheduler_restart_limit,
-            settings.torrent.scheduler_restart_period,
+            settings.torrent.scheduler_restart.limit,
+            settings.torrent.scheduler_restart.period,
          )
          .spawn()
          .await;
@@ -498,8 +498,8 @@ impl Actor for TorrentActor {
          )
          .restart_policy(RestartPolicy::Transient)
          .restart_limit(
-            settings.torrent.tracker_restart_limit,
-            settings.torrent.tracker_restart_period,
+            settings.torrent.tracker_restart.limit,
+            settings.torrent.tracker_restart.period,
          )
          .spawn()
          .await;
@@ -524,8 +524,8 @@ impl Actor for TorrentActor {
       let piece_store = PieceStoreActor::supervise(&us, ())
          .restart_policy(RestartPolicy::Permanent)
          .restart_limit(
-            settings.torrent.piece_store_restart_limit,
-            settings.torrent.piece_store_restart_period,
+            settings.torrent.piece_store_restart.limit,
+            settings.torrent.piece_store_restart.period,
          )
          .spawn()
          .await;

--- a/crates/libtortillas/src/torrent/actor.rs
+++ b/crates/libtortillas/src/torrent/actor.rs
@@ -5,7 +5,7 @@ use std::{
    ops::ControlFlow,
    path::PathBuf,
    sync::{Arc, atomic::AtomicU8},
-   time::{Duration, Instant},
+   time::Instant,
 };
 
 use async_trait::async_trait;
@@ -23,18 +23,18 @@ use librqbit_utp::UtpSocketUdp;
 use tokio::{sync::oneshot, task::AbortHandle};
 use tracing::{debug, error, info, instrument, trace, warn};
 
-use super::{
-   choking::{ChokingScheduler, RECHOKE_INTERVAL},
-   util,
-};
+use super::{choking::ChokingScheduler, util};
 use crate::{
    errors::TorrentError,
    hashes::InfoHash,
    metainfo::{Info, MetaInfo},
    peer::{PeerActor, PeerId},
    pieces::{FilePieceManager, PieceManager, PieceScheduler, PieceStoreActor},
+   settings::Settings,
    torrent::{BLOCK_SIZE, PieceStorageStrategy, TorrentExport, TorrentState},
-   tracker::{Announce, Event, Tracker, TrackerActor, TrackerUpdate, udp::UdpServer},
+   tracker::{
+      Announce, Event, Tracker, TrackerActor, TrackerActorArgs, TrackerUpdate, udp::UdpServer,
+   },
 };
 
 /// A hook that is called when the torrent is ready to start downloading.
@@ -120,6 +120,7 @@ pub(crate) struct TorrentActor {
    pub(super) pending_start: bool,
 
    pub(super) ready_hook: Vec<ReadyHookSender>,
+   pub(super) settings: Settings,
 }
 
 impl fmt::Display for TorrentActor {
@@ -226,7 +227,9 @@ impl TorrentActor {
       if self.state == TorrentState::Downloading {
          let peer_ids: Vec<_> = self.peers.keys().copied().collect();
          for peer_id in peer_ids {
-            self.request_blocks_from_peer(peer_id, 32).await;
+            self
+               .request_blocks_from_peer(peer_id, self.settings.torrent.initial_peer_request_window)
+               .await;
          }
       }
 
@@ -258,11 +261,12 @@ impl TorrentActor {
          next_rechoke.abort();
       }
 
+      let rechoke_interval = self.settings.torrent.rechoke_interval;
       match self
          .scheduler
          .ask(SetTimeout::new(
             self.actor_ref.downgrade(),
-            RECHOKE_INTERVAL,
+            rechoke_interval,
             super::commands::Rechoke,
          ))
          .await
@@ -272,7 +276,7 @@ impl TorrentActor {
             warn!(?err, "Failed to schedule next rechoke; using local timeout");
             let actor_ref = self.actor_ref.clone();
             let fallback = tokio::spawn(async move {
-               tokio::time::sleep(RECHOKE_INTERVAL).await;
+               tokio::time::sleep(rechoke_interval).await;
                if let Err(err) = actor_ref.tell(super::commands::Rechoke).await {
                   warn!(?err, "Failed to run fallback rechoke");
                }
@@ -424,6 +428,9 @@ pub struct TorrentActorArgs {
    ///
    /// If not provided, torrents will use their own default paths.
    pub base_path: Option<PathBuf>,
+
+   /// Runtime behavior settings.
+   pub settings: Settings,
 }
 
 impl Actor for TorrentActor {
@@ -446,6 +453,7 @@ impl Actor for TorrentActor {
          autostart,
          sufficient_peers,
          base_path,
+         settings,
       } = args;
 
       let torrent_id = metainfo.info_hash()?;
@@ -465,7 +473,10 @@ impl Actor for TorrentActor {
 
       let scheduler = Scheduler::supervise_with(&us, Scheduler::new)
          .restart_policy(RestartPolicy::Permanent)
-         .restart_limit(3, Duration::from_secs(10))
+         .restart_limit(
+            settings.torrent.scheduler_restart_limit,
+            settings.torrent.scheduler_restart_period,
+         )
          .spawn()
          .await;
 
@@ -475,17 +486,21 @@ impl Actor for TorrentActor {
       for tracker in tracker_list {
          let actor = TrackerActor::supervise(
             &us,
-            (
-               tracker.clone(),
+            TrackerActorArgs {
+               tracker: tracker.clone(),
                peer_id,
-               tracker_server.clone(),
-               primary_addr,
-               us.clone(),
-               scheduler.clone(),
-            ),
+               server: tracker_server.clone(),
+               socket_addr: primary_addr,
+               supervisor: us.clone(),
+               scheduler: scheduler.clone(),
+               settings: settings.tracker.clone(),
+            },
          )
          .restart_policy(RestartPolicy::Transient)
-         .restart_limit(3, Duration::from_secs(60))
+         .restart_limit(
+            settings.torrent.tracker_restart_limit,
+            settings.torrent.tracker_restart_period,
+         )
          .spawn()
          .await;
 
@@ -508,7 +523,10 @@ impl Actor for TorrentActor {
       let default_manager = FilePieceManager(base_path, info.clone());
       let piece_store = PieceStoreActor::supervise(&us, ())
          .restart_policy(RestartPolicy::Permanent)
-         .restart_limit(3, Duration::from_secs(10))
+         .restart_limit(
+            settings.torrent.piece_store_restart_limit,
+            settings.torrent.piece_store_restart_period,
+         )
          .spawn()
          .await;
 
@@ -527,14 +545,18 @@ impl Actor for TorrentActor {
          piece_store,
          state: TorrentState::default(),
          piece_scheduler: PieceScheduler::new(piece_count),
-         choking_scheduler: ChokingScheduler::default(),
+         choking_scheduler: ChokingScheduler::new(
+            settings.torrent.upload_slots,
+            settings.torrent.optimistic_unchoke_rounds,
+         ),
          next_rechoke: None,
          start_time: None,
-         sufficient_peers: sufficient_peers.unwrap_or(6),
-         autostart: autostart.unwrap_or(true),
+         sufficient_peers: sufficient_peers.unwrap_or(settings.torrent.sufficient_peers),
+         autostart: autostart.unwrap_or(settings.torrent.autostart),
          pending_start: false,
          ready_hook: Vec::new(),
          piece_manager: PieceManagerProxy::Default(default_manager),
+         settings,
       })
    }
 
@@ -591,6 +613,7 @@ mod tests {
    use super::*;
    use crate::{
       metainfo::MetaInfo,
+      settings::Settings,
       testing,
       torrent::{
          BLOCK_SIZE, Torrent, TorrentExport,
@@ -625,6 +648,7 @@ mod tests {
                                   * have peers */
          sufficient_peers: Some(sufficient_peers),
          base_path: None,
+         settings: Settings::default(),
       });
 
       let torrent = Torrent::new(info_hash, actor.clone());
@@ -657,6 +681,7 @@ mod tests {
          autostart: Some(false),
          sufficient_peers: None,
          base_path: None,
+         settings: Settings::default(),
       });
 
       // Blocking loop that runs until we get an info dict
@@ -722,6 +747,7 @@ mod tests {
          autostart: None,
          sufficient_peers: None,
          base_path: Some(file_path),
+         settings: Settings::default(),
       });
 
       let torrent = Torrent::new(info_hash, actor.clone());
@@ -796,6 +822,7 @@ mod tests {
          autostart: Some(false),
          sufficient_peers: Some(usize::MAX),
          base_path: Some(file_path.clone()),
+         settings: Settings::default(),
       });
 
       // Build the bitfield with fake completed pieces
@@ -844,6 +871,7 @@ mod tests {
          autostart: false,
          pending_start: false,
          ready_hook: Vec::new(),
+         settings: Settings::default(),
       };
 
       let export = test_actor.export();

--- a/crates/libtortillas/src/torrent/choking.rs
+++ b/crates/libtortillas/src/torrent/choking.rs
@@ -1,13 +1,8 @@
-use std::time::Duration;
-
 use crate::{
    peer::{PeerId, PeerStats},
+   settings::Settings,
    torrent::TorrentState,
 };
-
-pub(crate) const DEFAULT_UPLOAD_SLOTS: usize = 4;
-pub(crate) const RECHOKE_INTERVAL: Duration = Duration::from_secs(10);
-pub(crate) const OPTIMISTIC_UNCHOKE_ROUNDS: usize = 3;
 
 #[derive(Clone, Debug)]
 pub(crate) struct ChokingScheduler {
@@ -19,7 +14,11 @@ pub(crate) struct ChokingScheduler {
 
 impl Default for ChokingScheduler {
    fn default() -> Self {
-      Self::new(DEFAULT_UPLOAD_SLOTS, OPTIMISTIC_UNCHOKE_ROUNDS)
+      let settings = Settings::default();
+      Self::new(
+         settings.torrent.upload_slots,
+         settings.torrent.optimistic_unchoke_rounds,
+      )
    }
 }
 
@@ -155,8 +154,8 @@ mod tests {
       not_interested.interested = false;
       let peers = [stats(1), not_interested, stats(3)];
 
-      let decision =
-         select_unchoked_peers(&peers, TorrentState::Downloading, DEFAULT_UPLOAD_SLOTS, 0);
+      let upload_slots = Settings::default().torrent.upload_slots;
+      let decision = select_unchoked_peers(&peers, TorrentState::Downloading, upload_slots, 0);
 
       assert_eq!(decision.unchoked, vec![peer_id(1), peer_id(3)]);
       assert_eq!(decision.optimistic, None);
@@ -166,10 +165,10 @@ mod tests {
    fn selector_respects_upload_slot_limit() {
       let peers = [stats(1), stats(2), stats(3), stats(4), stats(5)];
 
-      let decision =
-         select_unchoked_peers(&peers, TorrentState::Downloading, DEFAULT_UPLOAD_SLOTS, 0);
+      let upload_slots = Settings::default().torrent.upload_slots;
+      let decision = select_unchoked_peers(&peers, TorrentState::Downloading, upload_slots, 0);
 
-      assert_eq!(decision.unchoked.len(), DEFAULT_UPLOAD_SLOTS);
+      assert_eq!(decision.unchoked.len(), upload_slots);
       assert_eq!(decision.optimistic, Some(peer_id(4)));
       assert_eq!(
          decision.unchoked,

--- a/crates/libtortillas/src/torrent/choking_flow.rs
+++ b/crates/libtortillas/src/torrent/choking_flow.rs
@@ -52,6 +52,7 @@ impl TorrentActor {
 
    async fn peer_stats(&self) -> Vec<PeerStats> {
       let peer_stats_timeout = self.settings.torrent.peer_stats_timeout;
+      let peer_stats_concurrency = self.settings.torrent.peer_stats_concurrency.max(1);
       let actor_refs: Vec<(crate::peer::PeerId, ActorRef<PeerActor>)> = self
          .peers
          .iter()
@@ -77,7 +78,7 @@ impl TorrentActor {
                }
             }
          })
-         .buffer_unordered(self.settings.torrent.peer_stats_concurrency)
+         .buffer_unordered(peer_stats_concurrency)
          .filter_map(std::future::ready)
          .collect()
          .await

--- a/crates/libtortillas/src/torrent/choking_flow.rs
+++ b/crates/libtortillas/src/torrent/choking_flow.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, time::Duration};
+use std::collections::HashSet;
 
 use futures::{StreamExt, stream};
 use kameo::actor::ActorRef;
@@ -13,9 +13,6 @@ use crate::{
    },
    torrent::TorrentState,
 };
-
-const PEER_STATS_CONCURRENCY: usize = 32;
-const PEER_STATS_TIMEOUT: Duration = Duration::from_millis(250);
 
 impl TorrentActor {
    pub(super) async fn rechoke_peers(&mut self) {
@@ -54,6 +51,7 @@ impl TorrentActor {
    }
 
    async fn peer_stats(&self) -> Vec<PeerStats> {
+      let peer_stats_timeout = self.settings.torrent.peer_stats_timeout;
       let actor_refs: Vec<(crate::peer::PeerId, ActorRef<PeerActor>)> = self
          .peers
          .iter()
@@ -63,7 +61,7 @@ impl TorrentActor {
 
       stream::iter(actor_refs)
          .map(|(peer_id, actor)| async move {
-            match timeout(PEER_STATS_TIMEOUT, actor.ask(Stats)).await {
+            match timeout(peer_stats_timeout, actor.ask(Stats)).await {
                Ok(Ok(Some(stats))) => Some(stats),
                Ok(Ok(None)) => {
                   trace!(%peer_id, "Peer stats unavailable");
@@ -79,7 +77,7 @@ impl TorrentActor {
                }
             }
          })
-         .buffer_unordered(PEER_STATS_CONCURRENCY)
+         .buffer_unordered(self.settings.torrent.peer_stats_concurrency)
          .filter_map(std::future::ready)
          .collect()
          .await

--- a/crates/libtortillas/src/torrent/messages.rs
+++ b/crates/libtortillas/src/torrent/messages.rs
@@ -23,8 +23,6 @@ use crate::{
    tracker::Tracker,
 };
 
-const MAX_IN_FLIGHT_PER_PEER: usize = 32;
-
 pub(crate) mod events {
    use super::*;
 
@@ -129,7 +127,7 @@ pub(crate) mod events {
             && self.is_ready()
          {
             self
-               .request_blocks_from_peer(id, MAX_IN_FLIGHT_PER_PEER)
+               .request_blocks_from_peer(id, self.settings.torrent.max_in_flight_per_peer)
                .await;
             trace!(peer_id = %id, "Filled peer request window");
          } else {

--- a/crates/libtortillas/src/torrent/piece_flow.rs
+++ b/crates/libtortillas/src/torrent/piece_flow.rs
@@ -456,7 +456,7 @@ mod tests {
       let info = test_info();
       let metainfo = test_metainfo(info.clone());
       let peer_id = testing::peer_id();
-      let tracker_server = UdpServer::new(None).await;
+      let tracker_server = UdpServer::new(None).await.unwrap();
       let utp_server = UtpSocket::new_udp(testing::ephemeral_socket_addr())
          .await
          .unwrap();

--- a/crates/libtortillas/src/torrent/piece_flow.rs
+++ b/crates/libtortillas/src/torrent/piece_flow.rs
@@ -412,6 +412,7 @@ mod tests {
       metainfo::{Info, InfoKeys, MetaInfo, TorrentFile},
       peer::PeerId,
       pieces::{FilePieceManager, PieceScheduler, PieceStoreActor},
+      settings::Settings,
       testing,
       torrent::{
          actor::{PieceManagerProxy, TorrentActorArgs},
@@ -470,6 +471,7 @@ mod tests {
          autostart: Some(false),
          sufficient_peers: Some(usize::MAX),
          base_path: Some(base_path.clone()),
+         settings: Settings::default(),
       });
 
       TorrentActor {
@@ -495,6 +497,7 @@ mod tests {
          autostart: false,
          pending_start: false,
          ready_hook: Vec::new(),
+         settings: Settings::default(),
       }
    }
 

--- a/crates/libtortillas/src/torrent/swarm.rs
+++ b/crates/libtortillas/src/torrent/swarm.rs
@@ -19,9 +19,6 @@ use crate::{
    tracker::{Tracker, TrackerActor, TrackerUpdate},
 };
 
-const PEER_BROADCAST_CONCURRENCY: usize = 32;
-const TRACKER_BROADCAST_CONCURRENCY: usize = 8;
-
 impl TorrentActor {
    #[instrument(skip(self, peer, stream), fields(%self, peer_addr = ?peer.socket_addr(), torrent_id = %self.info_hash()))]
    pub(super) fn append_peer(&self, mut peer: Peer, stream: Option<PeerStream>) {
@@ -105,9 +102,17 @@ impl TorrentActor {
 
       let actor_ref = self.actor_ref.clone();
       let info_hash = self.info_hash();
+      let peer_settings = self.settings.peer.clone();
+      let peer_mailbox_size = self.settings.torrent.peer_mailbox_size;
 
       self.peers.entry(id).or_insert_with(|| {
-         PeerActor::spawn_with_mailbox((peer, stream, actor_ref, info_hash), mailbox::bounded(120))
+         PeerActor::spawn_with_mailbox(
+            (peer, stream, actor_ref, info_hash, peer_settings),
+            match peer_mailbox_size {
+               0 => mailbox::unbounded(),
+               size => mailbox::bounded(size),
+            },
+         )
       });
    }
 
@@ -125,18 +130,21 @@ impl TorrentActor {
       let mut dead_peers = Vec::new();
 
       stream::iter(actor_refs)
-         .for_each_concurrent(PEER_BROADCAST_CONCURRENCY, |(id, actor)| {
-            let msg = tell.clone();
-            async move {
-               if actor.is_alive() {
-                  if let Err(e) = actor.tell(msg).await {
-                     warn!(error = %e, peer_id = %id, "Failed to send to peer");
+         .for_each_concurrent(
+            self.settings.torrent.peer_broadcast_concurrency,
+            |(id, actor)| {
+               let msg = tell.clone();
+               async move {
+                  if actor.is_alive() {
+                     if let Err(e) = actor.tell(msg).await {
+                        warn!(error = %e, peer_id = %id, "Failed to send to peer");
+                     }
+                  } else {
+                     trace!(peer_id = %id, "Peer actor is dead, removing from peers set");
                   }
-               } else {
-                  trace!(peer_id = %id, "Peer actor is dead, removing from peers set");
                }
-            }
-         })
+            },
+         )
          .await;
 
       for (id, actor) in &self.peers {
@@ -159,7 +167,7 @@ impl TorrentActor {
       let mut dead_trackers = Vec::new();
 
       stream::iter(actor_refs)
-         .for_each_concurrent(TRACKER_BROADCAST_CONCURRENCY, |(uri, actor)| {
+          .for_each_concurrent(self.settings.torrent.tracker_broadcast_concurrency, |(uri, actor)| {
             let msg = message.clone();
             async move {
                if actor.is_alive() {
@@ -196,7 +204,7 @@ impl TorrentActor {
       let mut dead_trackers = Vec::new();
 
       stream::iter(actor_refs)
-         .for_each_concurrent(TRACKER_BROADCAST_CONCURRENCY, |(uri, actor)| {
+          .for_each_concurrent(self.settings.torrent.tracker_broadcast_concurrency, |(uri, actor)| {
             let msg = tell.clone();
             async move {
                if actor.is_alive() {

--- a/crates/libtortillas/src/tracker/actor.rs
+++ b/crates/libtortillas/src/tracker/actor.rs
@@ -145,8 +145,19 @@ impl Actor for TrackerActor {
 #[messages]
 impl TrackerActor {
    async fn schedule_next_announce(&mut self) {
-      let delay = Duration::from_secs(self.tracker.interval() as u64)
+      let interval = self.tracker.interval();
+      let delay = if interval == usize::MAX || interval == u32::MAX as usize {
+         self.settings.fallback_announce_interval
+      } else {
+         Duration::from_secs(interval as u64)
+      };
+      let maximum_announce_interval = self
+         .settings
+         .maximum_announce_interval
          .max(self.settings.minimum_announce_interval);
+      let delay = delay
+         .max(self.settings.minimum_announce_interval)
+         .min(maximum_announce_interval);
       if let Some(next_announce) = self.next_announce.take() {
          next_announce.abort();
       }

--- a/crates/libtortillas/src/tracker/actor.rs
+++ b/crates/libtortillas/src/tracker/actor.rs
@@ -20,6 +20,7 @@ use super::{
 use crate::{
    errors::TrackerActorError,
    peer::PeerId,
+   settings::TrackerSettings,
    torrent::{self, TorrentActor},
 };
 
@@ -30,21 +31,34 @@ pub(crate) struct TrackerActor {
    scheduler: ActorRef<Scheduler>,
    next_announce: Option<AbortHandle>,
    actor_ref: ActorRef<Self>,
+   settings: TrackerSettings,
+}
+
+#[derive(Clone)]
+pub(crate) struct TrackerActorArgs {
+   pub(crate) tracker: Tracker,
+   pub(crate) peer_id: PeerId,
+   pub(crate) server: UdpServer,
+   pub(crate) socket_addr: SocketAddr,
+   pub(crate) supervisor: ActorRef<TorrentActor>,
+   pub(crate) scheduler: ActorRef<Scheduler>,
+   pub(crate) settings: TrackerSettings,
 }
 
 impl Actor for TrackerActor {
-   type Args = (
-      Tracker,
-      PeerId,
-      UdpServer,
-      SocketAddr,
-      ActorRef<TorrentActor>,
-      ActorRef<Scheduler>,
-   );
+   type Args = TrackerActorArgs;
    type Error = TrackerActorError;
 
    async fn on_start(state: Self::Args, actor_ref: ActorRef<Self>) -> Result<Self, Self::Error> {
-      let (tracker, peer_id, server, socket_addr, supervisor, scheduler) = state;
+      let TrackerActorArgs {
+         tracker,
+         peer_id,
+         server,
+         socket_addr,
+         supervisor,
+         scheduler,
+         settings,
+      } = state;
 
       let info_hash = supervisor
          .ask(torrent::commands::GetInfoHash)
@@ -54,12 +68,17 @@ impl Actor for TrackerActor {
       let tracker_uri = tracker.uri();
       let tracker = match tracker {
          Tracker::Udp(uri) => {
-            let udp_tracker =
-               UdpTracker::new(uri.clone(), Some(server), info_hash, (peer_id, socket_addr))
-                  .await
-                  .map_err(|_| TrackerActorError::InitializationFailed {
-                     tracker_type: format!("UDP: {uri}"),
-                  })?;
+            let udp_tracker = UdpTracker::new_with_settings(
+               uri.clone(),
+               Some(server),
+               info_hash,
+               (peer_id, socket_addr),
+               settings.clone(),
+            )
+            .await
+            .map_err(|_| TrackerActorError::InitializationFailed {
+               tracker_type: format!("UDP: {uri}"),
+            })?;
             udp_tracker.initialize().await.map_err(|_| {
                TrackerActorError::InitializationFailed {
                   tracker_type: format!("UDP: {uri}"),
@@ -68,8 +87,13 @@ impl Actor for TrackerActor {
             TrackerInstance::Udp(udp_tracker)
          }
          Tracker::Http(uri) => {
-            let http_tracker =
-               HttpTracker::new(uri.clone(), info_hash, Some(peer_id), Some(socket_addr));
+            let http_tracker = HttpTracker::new_with_settings(
+               uri.clone(),
+               info_hash,
+               Some(peer_id),
+               Some(socket_addr),
+               settings.clone(),
+            );
             http_tracker.initialize().await.map_err(|_| {
                TrackerActorError::InitializationFailed {
                   tracker_type: format!("HTTP: {uri}"),
@@ -87,7 +111,7 @@ impl Actor for TrackerActor {
       let next_announce = scheduler
          .ask(SetTimeout::new(
             actor_ref.downgrade(),
-            Duration::from_secs(0),
+            settings.initial_announce_delay,
             Announce,
          ))
          .await
@@ -99,6 +123,7 @@ impl Actor for TrackerActor {
          scheduler,
          next_announce: Some(next_announce),
          actor_ref,
+         settings,
       })
    }
 
@@ -109,7 +134,7 @@ impl Actor for TrackerActor {
          next_announce.abort();
       }
 
-      let _ = timeout(Duration::from_secs(5), self.tracker.stop())
+      let _ = timeout(self.settings.stop_timeout, self.tracker.stop())
          .await
          .inspect_err(|e| warn!(e = %e.to_string(), "Tracker stop timed out"));
 
@@ -120,17 +145,14 @@ impl Actor for TrackerActor {
 #[messages]
 impl TrackerActor {
    async fn schedule_next_announce(&mut self) {
-      let delay = self.tracker.interval().max(1) as u64;
+      let delay = Duration::from_secs(self.tracker.interval() as u64)
+         .max(self.settings.minimum_announce_interval);
       if let Some(next_announce) = self.next_announce.take() {
          next_announce.abort();
       }
       match self
          .scheduler
-         .ask(SetTimeout::new(
-            self.actor_ref.downgrade(),
-            Duration::from_secs(delay),
-            Announce,
-         ))
+         .ask(SetTimeout::new(self.actor_ref.downgrade(), delay, Announce))
          .await
       {
          Ok(next_announce) => self.next_announce = Some(next_announce),

--- a/crates/libtortillas/src/tracker/http.rs
+++ b/crates/libtortillas/src/tracker/http.rs
@@ -1,7 +1,6 @@
 use std::{
    fmt::Debug,
    net::{IpAddr, Ipv4Addr, SocketAddr},
-   str::FromStr,
    sync::{
       Arc,
       atomic::{AtomicUsize, Ordering},
@@ -25,6 +24,7 @@ use crate::{
    errors::TrackerActorError,
    hashes::InfoHash,
    peer::{Peer, PeerId},
+   settings::TrackerSettings,
    tracker::{Event, TrackerBase, TrackerStats, TrackerUpdate},
 };
 
@@ -60,7 +60,7 @@ struct TrackerRequest {
    event: Event,
    /// If we want peers in a compact format or not. Only applicable to HTTP
    /// trackers.
-   compact: Option<bool>,
+   compact: bool,
 }
 
 impl TrackerRequest {
@@ -87,7 +87,7 @@ impl TrackerRequest {
          params.push(format!("event={:?}", self.event).to_lowercase());
       }
 
-      params.push(format!("compact={}", self.compact.unwrap_or(true) as u8));
+      params.push(format!("compact={}", self.compact as u8));
 
       params.join("&")
    }
@@ -95,11 +95,12 @@ impl TrackerRequest {
    #[instrument(fields(peer_tracker_addr = ?peer_tracker_addr))]
    /// peer_tracker_addr refers to the port that we are listening on (which
    /// could be TCP, uTP, etc.).
-   pub fn new(peer_tracker_addr: Option<SocketAddr>) -> TrackerRequest {
+   pub fn new(
+      peer_tracker_addr: Option<SocketAddr>, default_peer_addr: SocketAddr, compact: bool,
+   ) -> TrackerRequest {
       let addr = peer_tracker_addr.unwrap_or_else(|| {
-         let default_addr = SocketAddr::from_str("0.0.0.0:6881").unwrap();
-         debug!(default_addr = %default_addr, "Using default peer tracker address");
-         default_addr
+         debug!(default_addr = %default_peer_addr, "Using default peer tracker address");
+         default_peer_addr
       });
 
       // If the ip address is 127.0.0.1 or 0.0.0.0 just dont send it since its
@@ -119,7 +120,7 @@ impl TrackerRequest {
          downloaded: 0,
          left: Some(0),
          event: Event::Stopped,
-         compact: Some(false),
+         compact,
       }
    }
 }
@@ -134,6 +135,7 @@ pub struct HttpTracker {
    params: Arc<RwLock<TrackerRequest>>,
    interval: Arc<AtomicUsize>,
    stats: TrackerStats,
+   settings: TrackerSettings,
 }
 
 impl HttpTracker {
@@ -146,12 +148,34 @@ impl HttpTracker {
       uri: String, info_hash: InfoHash, peer_id: Option<PeerId>,
       peer_tracker_addr: Option<SocketAddr>,
    ) -> HttpTracker {
+      Self::new_with_settings(
+         uri,
+         info_hash,
+         peer_id,
+         peer_tracker_addr,
+         TrackerSettings::default(),
+      )
+   }
+
+   #[instrument(skip(info_hash, peer_id, settings), fields(
+        tracker_uri = %uri,
+        torrent_id = %info_hash,
+        peer_addr = ?peer_tracker_addr
+    ))]
+   pub fn new_with_settings(
+      uri: String, info_hash: InfoHash, peer_id: Option<PeerId>,
+      peer_tracker_addr: Option<SocketAddr>, settings: TrackerSettings,
+   ) -> HttpTracker {
       let peer_id = peer_id.unwrap_or_else(|| {
          let id = PeerId::new();
          trace!(generated_peer_id = %id, "Generated new peer ID");
          id
       });
-      let params = TrackerRequest::new(peer_tracker_addr);
+      let params = TrackerRequest::new(
+         peer_tracker_addr,
+         settings.default_peer_addr,
+         settings.http_compact_response,
+      );
 
       debug!(
           peer_id = %peer_id,
@@ -166,6 +190,7 @@ impl HttpTracker {
          params,
          info_hash,
          stats: TrackerStats::default(),
+         settings,
       }
    }
 
@@ -279,8 +304,8 @@ impl TrackerBase for HttpTracker {
       {
          self.params.write().await.event = Event::Stopped;
       }
-      // Best‑effort, bounded final announce
-      match timeout(std::time::Duration::from_secs(3), self.announce()).await {
+      // Best-effort, bounded final announce.
+      match timeout(self.settings.http_stop_timeout, self.announce()).await {
          Ok(Ok(_)) => debug!("Stopped tracker"),
          Ok(Err(e)) => debug!(error = %e, "Stop announce failed; ignoring"),
          Err(_) => debug!("Stop announce timed out; ignoring"),

--- a/crates/libtortillas/src/tracker/mod.rs
+++ b/crates/libtortillas/src/tracker/mod.rs
@@ -4,6 +4,6 @@ mod model;
 mod stats;
 pub mod udp;
 
-pub(crate) use actor::{Announce, TrackerActor};
+pub(crate) use actor::{Announce, TrackerActor, TrackerActorArgs};
 pub use model::{Event, Tracker, TrackerBase, TrackerInstance, TrackerUpdate};
 pub use stats::TrackerStats;

--- a/crates/libtortillas/src/tracker/model.rs
+++ b/crates/libtortillas/src/tracker/model.rs
@@ -17,6 +17,7 @@ use super::{
 use crate::{
    hashes::InfoHash,
    peer::{Peer, PeerId},
+   settings::TrackerSettings,
 };
 
 /// An Announce URI from a torrent file or magnet URI.
@@ -36,17 +37,36 @@ impl Tracker {
    pub async fn to_base(
       &self, info_hash: InfoHash, peer_id: PeerId, port: u16, server: UdpServer,
    ) -> Result<Box<dyn TrackerBase>> {
+      self
+         .to_base_with_settings(info_hash, peer_id, port, server, TrackerSettings::default())
+         .await
+   }
+
+   pub async fn to_base_with_settings(
+      &self, info_hash: InfoHash, peer_id: PeerId, port: u16, server: UdpServer,
+      settings: TrackerSettings,
+   ) -> Result<Box<dyn TrackerBase>> {
       let socket_addr = SocketAddr::from(([0, 0, 0, 0], port));
       match self {
          Self::Http(uri) => {
-            let tracker =
-               HttpTracker::new(uri.clone(), info_hash, Some(peer_id), Some(socket_addr));
+            let tracker = HttpTracker::new_with_settings(
+               uri.clone(),
+               info_hash,
+               Some(peer_id),
+               Some(socket_addr),
+               settings,
+            );
             Ok(Box::new(tracker))
          }
          Self::Udp(uri) => {
-            let tracker =
-               UdpTracker::new(uri.clone(), Some(server), info_hash, (peer_id, socket_addr))
-                  .await?;
+            let tracker = UdpTracker::new_with_settings(
+               uri.clone(),
+               Some(server),
+               info_hash,
+               (peer_id, socket_addr),
+               settings,
+            )
+            .await?;
             Ok(Box::new(tracker))
          }
          Self::Websocket(uri) => anyhow::bail!("websocket trackers are not supported: {uri}"),
@@ -56,17 +76,36 @@ impl Tracker {
    pub async fn to_instance(
       &self, info_hash: InfoHash, peer_id: PeerId, port: u16, server: UdpServer,
    ) -> Result<TrackerInstance> {
+      self
+         .to_instance_with_settings(info_hash, peer_id, port, server, TrackerSettings::default())
+         .await
+   }
+
+   pub async fn to_instance_with_settings(
+      &self, info_hash: InfoHash, peer_id: PeerId, port: u16, server: UdpServer,
+      settings: TrackerSettings,
+   ) -> Result<TrackerInstance> {
       let socket_addr = SocketAddr::from(([0, 0, 0, 0], port));
       match self {
          Self::Http(uri) => {
-            let tracker =
-               HttpTracker::new(uri.clone(), info_hash, Some(peer_id), Some(socket_addr));
+            let tracker = HttpTracker::new_with_settings(
+               uri.clone(),
+               info_hash,
+               Some(peer_id),
+               Some(socket_addr),
+               settings,
+            );
             Ok(TrackerInstance::Http(tracker))
          }
          Self::Udp(uri) => {
-            let tracker =
-               UdpTracker::new(uri.clone(), Some(server), info_hash, (peer_id, socket_addr))
-                  .await?;
+            let tracker = UdpTracker::new_with_settings(
+               uri.clone(),
+               Some(server),
+               info_hash,
+               (peer_id, socket_addr),
+               settings,
+            )
+            .await?;
             Ok(TrackerInstance::Udp(tracker))
          }
          Self::Websocket(uri) => anyhow::bail!("websocket trackers are not supported: {uri}"),

--- a/crates/libtortillas/src/tracker/udp.rs
+++ b/crates/libtortillas/src/tracker/udp.rs
@@ -356,7 +356,7 @@ impl UdpServer {
    /// trackers with a singular [UdpSocket]
    ///
    /// Only fails if the `addr` is in use
-   pub async fn new(addr: Option<SocketAddr>) -> Self {
+   pub async fn new(addr: Option<SocketAddr>) -> Result<Self> {
       Self::new_with_receive_buffer_size(addr, TrackerSettings::default().udp_receive_buffer_size)
          .await
    }
@@ -364,9 +364,13 @@ impl UdpServer {
    /// Creates a new UDP Server with a custom receive buffer size.
    pub async fn new_with_receive_buffer_size(
       addr: Option<SocketAddr>, receive_buffer_size: usize,
-   ) -> Self {
+   ) -> Result<Self> {
       let addr = addr.unwrap_or(SocketAddr::from_str("0.0.0.0:0").unwrap());
-      let socket = Arc::new(UdpSocket::bind(addr).await.unwrap());
+      let socket = Arc::new(
+         UdpSocket::bind(addr)
+            .await
+            .map_err(TrackerActorError::Network)?,
+      );
 
       let receiver = UdpServer {
          response_channels: Arc::new(DashMap::new()),
@@ -375,7 +379,7 @@ impl UdpServer {
 
       // Start the message receiving task
       receiver.start_receiver_task(receive_buffer_size).await;
-      receiver
+      Ok(receiver)
    }
 
    pub fn local_addr(&self) -> SocketAddr {
@@ -383,14 +387,14 @@ impl UdpServer {
    }
 
    /// Register a transaction ID with a response channel
-   async fn register_transaction(
+   fn register_transaction(
       &self, transaction_id: TransactionId, sender: mpsc::UnboundedSender<(usize, TrackerResponse)>,
    ) {
       self.response_channels.insert(transaction_id, sender);
    }
 
    /// Unregister a transaction ID
-   pub async fn unregister_transaction(&self, transaction_id: &TransactionId) {
+   pub fn unregister_transaction(&self, transaction_id: &TransactionId) {
       self.response_channels.remove(transaction_id);
    }
 
@@ -455,6 +459,35 @@ impl UdpServer {
          })?;
 
       Ok(())
+   }
+}
+
+struct TransactionRegistration {
+   server: UdpServer,
+   transaction_id: TransactionId,
+   active: bool,
+}
+
+impl TransactionRegistration {
+   fn new(server: UdpServer, transaction_id: TransactionId) -> Self {
+      Self {
+         server,
+         transaction_id,
+         active: true,
+      }
+   }
+
+   fn unregister(mut self) {
+      self.server.unregister_transaction(&self.transaction_id);
+      self.active = false;
+   }
+}
+
+impl Drop for TransactionRegistration {
+   fn drop(&mut self) {
+      if self.active {
+         self.server.unregister_transaction(&self.transaction_id);
+      }
    }
 }
 
@@ -587,7 +620,7 @@ impl UdpTracker {
       let server = match server {
          Some(receiver) => receiver,
          None => {
-            UdpServer::new_with_receive_buffer_size(None, settings.udp_receive_buffer_size).await
+            UdpServer::new_with_receive_buffer_size(None, settings.udp_receive_buffer_size).await?
          }
       };
 
@@ -703,14 +736,14 @@ impl UdpTracker {
 
       self
          .server
-         .register_transaction(*transaction_id, response_tx)
-         .await;
+         .register_transaction(*transaction_id, response_tx);
+      let registration = TransactionRegistration::new(self.server.clone(), *transaction_id);
 
       // Send the message through the shared message receiver
       let send_result = self.server.send_message(&message_bytes, self.addr).await;
 
       if let Err(err) = send_result {
-         self.server.unregister_transaction(transaction_id).await;
+         registration.unregister();
          return Err(RetryError::Permanent(err));
       }
 
@@ -722,11 +755,9 @@ impl UdpTracker {
           "Sent message to tracker"
       );
 
-      let response = self
+      self
          .recv_registered_response(transaction_id, &mut response_rx)
-         .await;
-      self.server.unregister_transaction(transaction_id).await;
-      response
+         .await
    }
 
    /// Sends a message with exponential backoff to a tracker. Retry timing is

--- a/crates/libtortillas/src/tracker/udp.rs
+++ b/crates/libtortillas/src/tracker/udp.rs
@@ -26,6 +26,7 @@ use crate::{
    errors::TrackerActorError,
    hashes::InfoHash,
    peer::{Peer, PeerId},
+   settings::TrackerSettings,
    tracker::{Event, TrackerBase, TrackerStats, TrackerUpdate},
 };
 
@@ -39,6 +40,11 @@ type AtomicConnectionId = AtomicU64;
 type TransactionId = u32;
 /// A type alias for all Results in this file, for convenience.
 type Result<T> = anyhow::Result<T, TrackerActorError>;
+
+fn duration_millis(duration: Duration) -> u64 {
+   duration.as_millis().min(u64::MAX as u128) as u64
+}
+
 /// A magic constant for the UDP tracker protocol. needed in
 /// [TrackerRequest::Connect]
 const MAGIC_CONSTANT: ConnectionId = 0x41727101980;
@@ -48,13 +54,8 @@ const MIN_CONNECT_RESPONSE_SIZE: usize = 16;
 const MIN_ANNOUNCE_RESPONSE_SIZE: usize = 20;
 /// Minimum error response size, in bytes
 const MIN_ERROR_RESPONSE_SIZE: usize = 8;
-/// The maximum amount of time a connect message can take to respond.
-/// This hard-caps the retries regardless of [MESSAGE_TIMEOUT]
-const CONNECTION_TIMEOUT: Duration = Duration::from_secs(3);
 /// The size of each peer returned from a tracker, in bytes
 const PEER_SIZE: usize = 6;
-/// The maximum amount of time a message can take to respond.
-const MESSAGE_TIMEOUT: Duration = Duration::from_millis(300);
 
 /// Tracker request variants with binary layouts.
 #[derive(Debug)]
@@ -356,6 +357,14 @@ impl UdpServer {
    ///
    /// Only fails if the `addr` is in use
    pub async fn new(addr: Option<SocketAddr>) -> Self {
+      Self::new_with_receive_buffer_size(addr, TrackerSettings::default().udp_receive_buffer_size)
+         .await
+   }
+
+   /// Creates a new UDP Server with a custom receive buffer size.
+   pub async fn new_with_receive_buffer_size(
+      addr: Option<SocketAddr>, receive_buffer_size: usize,
+   ) -> Self {
       let addr = addr.unwrap_or(SocketAddr::from_str("0.0.0.0:0").unwrap());
       let socket = Arc::new(UdpSocket::bind(addr).await.unwrap());
 
@@ -365,7 +374,7 @@ impl UdpServer {
       };
 
       // Start the message receiving task
-      receiver.start_receiver_task().await;
+      receiver.start_receiver_task(receive_buffer_size).await;
       receiver
    }
 
@@ -387,11 +396,9 @@ impl UdpServer {
 
    /// Start the background task that receives messages and routes them to
    /// correct channels
-   async fn start_receiver_task(&self) {
+   async fn start_receiver_task(&self, receive_buffer_size: usize) {
       let receiver = self.clone();
-      // UDP tracker messages are typically small (< 1500 bytes for MTU)
-      // Largest expected response is announce with many peers
-      let mut buf = vec![0u8; 8192]; // 8KB should be sufficient for tracker responses
+      let mut buf = vec![0u8; receive_buffer_size.max(1)];
 
       let response_channels = self.response_channels.clone();
       tokio::spawn(async move {
@@ -527,6 +534,8 @@ pub struct UdpTracker {
    stats: TrackerStats,
    /// Parameters for announce request. See [AnnounceParams].
    announce_params: Arc<RwLock<AnnounceParams>>,
+   /// Runtime tracker settings.
+   settings: TrackerSettings,
 }
 
 impl UdpTracker {
@@ -543,6 +552,25 @@ impl UdpTracker {
    pub async fn new(
       uri: String, server: Option<UdpServer>, info_hash: InfoHash, peer_info: (PeerId, SocketAddr),
    ) -> Result<UdpTracker> {
+      Self::new_with_settings(
+         uri,
+         server,
+         info_hash,
+         peer_info,
+         TrackerSettings::default(),
+      )
+      .await
+   }
+
+   #[instrument(skip(info_hash, peer_info, server, settings), fields(
+        tracker_uri = %uri,
+        torrent_id = %info_hash,
+        server_addr = ?server.clone().map(|s| s.local_addr())
+    ))]
+   pub async fn new_with_settings(
+      uri: String, server: Option<UdpServer>, info_hash: InfoHash, peer_info: (PeerId, SocketAddr),
+      settings: TrackerSettings,
+   ) -> Result<UdpTracker> {
       let (peer_id, peer_addr) = peer_info;
       let addrs = lookup_host(&uri.replace("udp://", ""))
          .await
@@ -558,7 +586,9 @@ impl UdpTracker {
       // Create or use existing message receiver
       let server = match server {
          Some(receiver) => receiver,
-         None => UdpServer::new(None).await,
+         None => {
+            UdpServer::new_with_receive_buffer_size(None, settings.udp_receive_buffer_size).await
+         }
       };
 
       debug!("Started new UDP tracker");
@@ -575,6 +605,7 @@ impl UdpTracker {
          peer_addr,
          stats: TrackerStats::default(),
          announce_params: Arc::new(RwLock::new(AnnounceParams::default())),
+         settings,
       })
    }
 
@@ -614,7 +645,8 @@ impl UdpTracker {
       response_rx: &mut mpsc::UnboundedReceiver<ServerMessage>,
    ) -> anyhow::Result<TrackerResponse, RetryError<TrackerActorError>> {
       // Create a timeout for the response
-      let timeout_result = timeout(MESSAGE_TIMEOUT, response_rx.recv()).await;
+      let message_timeout = self.settings.udp_message_timeout;
+      let timeout_result = timeout(message_timeout, response_rx.recv()).await;
 
       match timeout_result {
          Ok(Some((size, response))) => {
@@ -635,7 +667,7 @@ impl UdpTracker {
             );
             return Err(RetryError::Transient {
                err: TrackerActorError::RequestTimeout {
-                  seconds: MESSAGE_TIMEOUT.as_secs().max(1),
+                  seconds: message_timeout.as_secs().max(1),
                },
                retry_after: None,
             });
@@ -643,12 +675,12 @@ impl UdpTracker {
          Err(_) => {
             trace!(
                 transaction_id = transaction_id,
-                elapsed = ?MESSAGE_TIMEOUT,
+                elapsed = ?message_timeout,
                 "Tracker timed out"
             );
             return Err(RetryError::Transient {
                err: TrackerActorError::RequestTimeout {
-                  seconds: MESSAGE_TIMEOUT.as_secs().max(1),
+                  seconds: message_timeout.as_secs().max(1),
                },
                retry_after: None,
             });
@@ -697,15 +729,8 @@ impl UdpTracker {
       response
    }
 
-   /// Sends a message with exponential backoff to a tracker. The following
-   /// refers to the exponential backoff settings used in this function:
-   ///
-   /// ```ignore
-   /// let retry_strategy = ExponentialBackoff::from_millis(15 * 1000)
-   ///    .factor(2)
-   ///    .max_delay_millis(3840 * 1000)
-   ///    .take(8);
-   /// ```
+   /// Sends a message with exponential backoff to a tracker. Retry timing is
+   /// controlled by [`TrackerSettings`].
    ///
    /// The following refers to the reasoning of why exponential backoff is
    /// utilized, from BEP 0015.
@@ -729,10 +754,11 @@ impl UdpTracker {
          transaction_id = transaction_id,
          "Transaction ID for tracker"
       );
-      let retry_strategy = ExponentialBackoff::from_millis(15 * 1000)
-         .factor(2)
-         .max_delay_millis(3840 * 1000)
-         .take(8);
+      let retry_strategy =
+         ExponentialBackoff::from_millis(duration_millis(self.settings.udp_retry_initial_delay))
+            .factor(self.settings.udp_retry_factor)
+            .max_delay_millis(duration_millis(self.settings.udp_retry_max_delay))
+            .take(self.settings.udp_retry_attempts);
 
       fn log_retry(err: &TrackerActorError, elapsed: Duration) {
          tracing::warn!(error = ?err, elapsed = ?elapsed, "Tracker message failed, retrying...");
@@ -757,10 +783,11 @@ impl UdpTracker {
       let transaction_id: TransactionId = rand::random();
 
       let request = TrackerRequest::Connect(MAGIC_CONSTANT, Action::Connect, transaction_id);
-      let response = timeout(CONNECTION_TIMEOUT, self.send_and_wait(request)).await;
+      let connect_timeout = self.settings.udp_connect_timeout;
+      let response = timeout(connect_timeout, self.send_and_wait(request)).await;
 
       let response = response.map_err(|_| TrackerActorError::RequestTimeout {
-         seconds: CONNECTION_TIMEOUT.as_secs().max(1),
+         seconds: connect_timeout.as_secs().max(1),
       })??;
 
       match response {
@@ -828,7 +855,8 @@ impl TrackerBase for UdpTracker {
 
       self.stats.increment_announce_attempts();
 
-      for attempt in 0..2 {
+      let connection_id_retry_attempts = self.settings.udp_connection_id_retry_attempts.max(1);
+      for attempt in 0..connection_id_retry_attempts {
          let transaction_id: TransactionId = rand::random();
 
          let (downloaded, left, uploaded, event) = {
@@ -850,9 +878,9 @@ impl TrackerBase for UdpTracker {
             left,
             uploaded,
             event,
-            ip_address: 0,
-            key: 0,
-            num_want: -1,
+            ip_address: self.settings.udp_announce_ip_address,
+            key: self.settings.udp_announce_key,
+            num_want: self.settings.udp_num_want,
             port: self.peer_addr.port(),
          };
 
@@ -895,7 +923,9 @@ impl TrackerBase for UdpTracker {
                transaction_id,
                ..
             } => {
-               if attempt == 0 && message.to_ascii_lowercase().contains("connection id") {
+               if attempt + 1 < connection_id_retry_attempts
+                  && message.to_ascii_lowercase().contains("connection id")
+               {
                   warn!(
                      error_message = %message,
                      transaction_id = transaction_id,


### PR DESCRIPTION
## Summary
- Add public Settings types for engine, torrent, peer, and tracker runtime defaults
- Thread settings through engine, torrent, peer, tracker, and UDP/HTTP tracker construction
- Keep protocol/BEP wire constants local while preserving existing defaults and builder overrides

## Tests
- cargo test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable runtime settings for engine, torrent, peer, and tracker behavior.
  * Exposed the new settings in the public API for easier customization.

* **Bug Fixes**
  * Replaced several fixed timeouts, retry limits, and concurrency values with configurable defaults.
  * Improved tracker and peer handling to better respect configured connection and announce timing.

* **Refactor**
  * Consolidated runtime configuration into shared settings across engine, torrent, peer, and tracker components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->