### PR TITLE
fix: peer actor not closing from unrecoverable io errors

### DIFF
--- a/crates/libtortillas/src/peer/actor.rs
+++ b/crates/libtortillas/src/peer/actor.rs
@@ -112,13 +112,12 @@ impl PeerActor {
             use std::io::ErrorKind::*;
             debug!(error = ?e, "Peer errored");
             match e {
-               PeerActorError::Io(e) | PeerActorError::ReceiveFailed(e) => {
-                  if e.kind() == UnexpectedEof || e.kind() == ConnectionReset {
-                     Some(Signal::Stop)
-                  } else {
-                     None
-                  }
-               }
+               PeerActorError::Io(e) | PeerActorError::ReceiveFailed(e) => match e.kind() {
+                  UnexpectedEof | ConnectionReset | ConnectionAborted => Some(Signal::Stop),
+
+                  Other | NotConnected | BrokenPipe => Some(Signal::Stop),
+                  _ => None,
+               },
                _ => None,
             }
          }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection handling so message processing stops more reliably when a peer disconnects or the link is broken.
  * Added support for additional network error cases, including aborted connections, not connected, broken pipe, and other related failures.
  * Preserved existing behavior for unrelated errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->