### PR TITLE
docs: document libtortillas Tokio runtime boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,19 @@ Libtortillas is the library that powers the frontend TUI application. It is a li
 ```bash
 cargo add --git https://github.com/artrixdotdev/tortillas libtortillas
 ```
+
+#### Runtime Contract
+
+`libtortillas` is a Tokio-first library. Applications that use it must run
+engine and torrent operations inside a Tokio runtime.
+
+For the Tortillas TUI, the binary should own a single application runtime,
+typically through `#[tokio::main]`, and create `libtortillas::engine::Engine`
+inside that runtime. UI rendering or terminal input that blocks should run on a
+dedicated thread or through Tokio blocking tasks, then send commands into async
+engine tasks. The library does not currently support swapping in a different
+async runtime, HTTP client, clock, listener, or storage executor.
+
 ## 🤝 Contributing
 
 We welcome contributions! If you'd like to help improve `tortillas`, please check out our [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines and tips.

--- a/README.md
+++ b/README.md
@@ -87,9 +87,11 @@ engine and torrent operations inside a Tokio runtime.
 For the Tortillas TUI, the binary should own a single application runtime,
 typically through `#[tokio::main]`, and create `libtortillas::engine::Engine`
 inside that runtime. UI rendering or terminal input that blocks should run on a
-dedicated thread or through Tokio blocking tasks, then send commands into async
-engine tasks. The library does not currently support swapping in a different
-async runtime, HTTP client, clock, listener, or storage executor.
+dedicated thread or, for bounded work, through Tokio blocking tasks, then send
+commands into async engine tasks. Long-lived input loops should use a dedicated
+thread because `spawn_blocking` tasks cannot be aborted once they start. The
+library does not currently support swapping in a different async runtime, HTTP
+client, clock, listener, or storage executor.
 
 ## 🤝 Contributing
 

--- a/crates/libtortillas/src/ARCHITECTURE.md
+++ b/crates/libtortillas/src/ARCHITECTURE.md
@@ -10,6 +10,25 @@ The library is organized around a small actor hierarchy:
 Module facades should export stable public types while keeping actor internals private to the crate.
 Domain types such as torrent state, storage strategy, exported snapshots, tracker model types, and tracker stats live outside actor files so actors can focus on orchestration.
 
+## Runtime Boundary
+
+`libtortillas` is intentionally tied to Tokio. The crate uses Tokio for actor
+task execution, TCP and UDP sockets, timers, cancellation, channels, and
+filesystem work. HTTP fetching is also part of the library runtime path through
+`reqwest`.
+
+Frontend applications should treat Tokio as the runtime boundary. A frontend,
+including the planned Tortillas TUI, should create one Tokio runtime at process
+startup and run `Engine` plus all torrent handle operations on that runtime. If
+the UI layer has blocking terminal rendering or input loops, those should be
+isolated from async torrent work with channels, a dedicated UI thread, or
+`tokio::task::spawn_blocking`.
+
+Runtime independence is not a current API promise. The public facade should not
+claim support for custom async runtimes, injected HTTP clients, injected clocks,
+custom network listeners, or non-Tokio storage executors unless those extension
+points are added explicitly.
+
 ## Torrent Lifecycle
 
 `TorrentState` is the frontend-facing lifecycle contract exported in torrent snapshots.

--- a/crates/libtortillas/src/ARCHITECTURE.md
+++ b/crates/libtortillas/src/ARCHITECTURE.md
@@ -21,8 +21,10 @@ Frontend applications should treat Tokio as the runtime boundary. A frontend,
 including the planned Tortillas TUI, should create one Tokio runtime at process
 startup and run `Engine` plus all torrent handle operations on that runtime. If
 the UI layer has blocking terminal rendering or input loops, those should be
-isolated from async torrent work with channels, a dedicated UI thread, or
-`tokio::task::spawn_blocking`.
+isolated from async torrent work with channels and a dedicated UI thread.
+`tokio::task::spawn_blocking` is suitable for bounded blocking operations, but
+not a long-lived input loop: a blocking task cannot be aborted after it starts
+and can delay runtime shutdown.
 
 Runtime independence is not a current API promise. The public facade should not
 claim support for custom async runtimes, injected HTTP clients, injected clocks,

--- a/crates/libtortillas/src/engine/mod.rs
+++ b/crates/libtortillas/src/engine/mod.rs
@@ -81,18 +81,26 @@ use crate::{
 /// use std::net::SocketAddr;
 ///
 /// use libtortillas::prelude::*;
-/// // Create an engine with no explicit addresses
-/// let engine = Engine::builder()
-///    // Optionally provide addresses for our sockets to listen on
-///    .tcp_addr("127.0.0.1:6881".parse::<SocketAddr>().unwrap())
-///    .utp_addr("127.0.0.1:6882".parse::<SocketAddr>().unwrap())
-///    .udp_addr("127.0.0.1:6883".parse::<SocketAddr>().unwrap())
-///    .build();
+///
+/// #[tokio::main]
+/// async fn main() {
+///    // Create an engine with no explicit addresses
+///    let engine = Engine::builder()
+///       // Optionally provide addresses for our sockets to listen on
+///       .tcp_addr("127.0.0.1:6881".parse::<SocketAddr>().unwrap())
+///       .utp_addr("127.0.0.1:6882".parse::<SocketAddr>().unwrap())
+///       .udp_addr("127.0.0.1:6883".parse::<SocketAddr>().unwrap())
+///       .build();
+/// }
 /// ```
 /// Or with all default settings
 /// ```no_run
 /// use libtortillas::prelude::*;
-/// let engine = Engine::default();
+///
+/// #[tokio::main]
+/// async fn main() {
+///    let engine = Engine::default();
+/// }
 /// ```
 #[derive(Debug, Clone)]
 pub struct Engine(ActorRef<EngineActor>);

--- a/crates/libtortillas/src/engine/mod.rs
+++ b/crates/libtortillas/src/engine/mod.rs
@@ -14,6 +14,13 @@
 //! - Each torrent is represented by a [`Torrent`] handle, which can be used to
 //!   interact with the torrent session.
 //!
+//! ## Runtime
+//!
+//! The engine is Tokio-only. Construct and use [`Engine`] from tasks running on
+//! a Tokio runtime, such as a TUI binary with `#[tokio::main]`. `Engine` starts
+//! actor tasks, binds Tokio TCP and uTP sockets, uses Tokio timers, and
+//! performs async filesystem and HTTP work through the same runtime.
+//!
 //! ## Example
 //!
 //! ```no_run
@@ -61,6 +68,10 @@ use crate::{
 /// - Spawning and supervising the lower level `EngineActor`
 /// - Adding new [torrents](Torrent) from different sources
 /// - Managing peer connections and tracker communication
+///
+/// `Engine` must be created and used from a Tokio runtime. Applications should
+/// create one runtime at the frontend boundary and run all engine and torrent
+/// operations on that runtime.
 ///
 /// Typically, you create a single `Engine` instance per application and attach
 /// multiple [`Torrent`] instances to it.

--- a/crates/libtortillas/src/lib.rs
+++ b/crates/libtortillas/src/lib.rs
@@ -1,3 +1,20 @@
+//! Async BitTorrent engine for building Tortillas frontends.
+//!
+//! # Runtime boundary
+//!
+//! `libtortillas` is intentionally a Tokio-based library. Public handles such
+//! as [`engine::Engine`] and [`torrent::Torrent`] expose async methods that
+//! must be driven inside a Tokio runtime, and the crate uses Tokio tasks,
+//! sockets, timers, channels, and filesystem APIs internally.
+//!
+//! Frontends should create one application-level Tokio runtime and keep the
+//! engine plus all torrent handles on work scheduled by that runtime. The crate
+//! does not promise runtime independence, HTTP client injection, clock
+//! injection, listener injection, or storage runtime abstraction.
+//!
+//! A TUI can use `#[tokio::main]` on its binary entry point, or create an
+//! explicit Tokio runtime before initializing `Engine`.
+
 pub mod engine;
 pub mod errors;
 pub mod hashes;


### PR DESCRIPTION
## Summary
- Document libtortillas as intentionally Tokio-only in crate and Engine docs.
- Add frontend/TUI guidance for owning one Tokio runtime and isolating blocking UI work.
- Clarify that runtime, HTTP client, clock, listener, and storage executor injection are not current API promises.

## Testing
- cargo fmt --all -- --check
- cargo nextest run --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc -p libtortillas --no-deps

Ignored network tests were not run because this is documentation-only and does not change network behavior.

Closes #237
Part of #221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance explaining that `libtortillas` operations must run within a Tokio runtime.
  * Documented recommended patterns for integrating blocking terminal or UI input with asynchronous engine tasks.
  * Clarified runtime requirements and limitations, including the lack of guarantees for custom runtime or infrastructure substitutions.
  * Updated usage examples to demonstrate running the engine within Tokio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->