### PR TITLE
refactor: clarify torrent lifecycle states

### DIFF
--- a/crates/libtortillas/src/ARCHITECTURE.md
+++ b/crates/libtortillas/src/ARCHITECTURE.md
@@ -10,6 +10,16 @@ The library is organized around a small actor hierarchy:
 Module facades should export stable public types while keeping actor internals private to the crate.
 Domain types such as torrent state, storage strategy, exported snapshots, tracker model types, and tracker stats live outside actor files so actors can focus on orchestration.
 
+## Torrent Lifecycle
+
+`TorrentState` is the frontend-facing lifecycle contract exported in torrent snapshots.
+New torrents start as `Added` when metadata is already available, or `ResolvingMetadata` when a source such as a magnet URI still needs an info dict.
+Once metadata and the configured peer threshold are available, a torrent becomes `Ready` if autostart is disabled, or moves directly into `Downloading` when autostart/manual start begins transfer.
+
+Completed downloads transition to `Seeding`.
+`Paused` is distinct from `Ready` and is not eligible for autostart, so frontends can intentionally hold a torrent without it being treated as merely inactive.
+Shutdown and failure paths report `Stopping`, `Stopped`, or `Failed` instead of collapsing those cases into the same state as a paused or newly added torrent.
+
 ## Choking
 
 `TorrentActor` owns the BEP 3 choking scheduler for its swarm. Active torrents run a rechoke round every 10 seconds, collect peer-local transfer stats from `PeerActor`, and keep at most four interested peers unchoked.

--- a/crates/libtortillas/src/torrent/actor.rs
+++ b/crates/libtortillas/src/torrent/actor.rs
@@ -182,7 +182,7 @@ impl TorrentActor {
             trace!("Autostarting torrent");
             self.start().await;
          } else {
-            // Torrent is ready, but auto-start is disabled
+            self.state = TorrentState::Ready;
             self.send_ready_hooks();
          }
       }
@@ -191,15 +191,22 @@ impl TorrentActor {
    }
 
    pub async fn start(&mut self) {
+      if !self.state.can_start() {
+         trace!(state = ?self.state, "Ignoring start while torrent cannot start");
+         return;
+      }
+
       self.send_ready_hooks();
 
       let Some(info) = self.info.clone() else {
+         self.state = TorrentState::ResolvingMetadata;
          warn!(id = %self.info_hash(), "Start requested before info dict is available; deferring");
          return;
       };
 
       // Pre-start the piece manager before transitioning state
       if let Err(err) = self.piece_manager.pre_start(info.clone()).await {
+         self.state = TorrentState::Failed;
          error!(?err, "Failed to pre-start piece manager; aborting start");
          return;
       }
@@ -250,10 +257,7 @@ impl TorrentActor {
    }
 
    pub(super) async fn schedule_next_rechoke(&mut self) {
-      if !matches!(
-         self.state,
-         TorrentState::Downloading | TorrentState::Seeding
-      ) {
+      if !self.state.is_transfer_active() {
          return;
       }
 
@@ -372,7 +376,7 @@ impl TorrentActor {
    }
 
    pub fn is_ready_to_start(&self) -> bool {
-      self.is_ready() && self.state == TorrentState::Inactive
+      self.is_ready() && self.state.can_become_ready()
    }
 }
 
@@ -519,6 +523,11 @@ impl Actor for TorrentActor {
       } else {
          0
       };
+      let initial_state = if info.is_some() {
+         TorrentState::Added
+      } else {
+         TorrentState::ResolvingMetadata
+      };
       let bitfield = BitVec::repeat(false, piece_count);
       let default_manager = FilePieceManager(base_path, info.clone());
       let piece_store = PieceStoreActor::supervise(&us, ())
@@ -543,7 +552,7 @@ impl Actor for TorrentActor {
          actor_ref: us,
          piece_storage,
          piece_store,
-         state: TorrentState::default(),
+         state: initial_state,
          piece_scheduler: PieceScheduler::new(piece_count),
          choking_scheduler: ChokingScheduler::new(
             settings.torrent.upload_slots,
@@ -573,6 +582,7 @@ impl Actor for TorrentActor {
    async fn on_stop(
       &mut self, _: WeakActorRef<Self>, reason: ActorStopReason,
    ) -> Result<(), Self::Error> {
+      self.state = TorrentState::Stopping;
       info!(reason = %reason, "Torrent stopped");
       for peer in self.peers.values() {
          peer.kill();
@@ -585,6 +595,7 @@ impl Actor for TorrentActor {
       }
       self.piece_store.kill();
       self.scheduler.kill();
+      self.state = TorrentState::Stopped;
 
       Ok(())
    }
@@ -862,7 +873,7 @@ mod tests {
             Some(file_path),
             Some(info_dict.clone()),
          )),
-         state: TorrentState::Inactive,
+         state: TorrentState::Added,
          piece_scheduler,
          choking_scheduler: ChokingScheduler::default(),
          next_rechoke: None,
@@ -878,7 +889,7 @@ mod tests {
 
       // Verify export contents
       assert_eq!(export.info_hash, info_hash);
-      assert_eq!(export.state, TorrentState::Inactive);
+      assert_eq!(export.state, TorrentState::Added);
       assert!(!export.auto_start);
       assert_eq!(export.sufficient_peers, 6);
       assert!(export.info_dict.is_some(), "Info dict should be present");

--- a/crates/libtortillas/src/torrent/actor.rs
+++ b/crates/libtortillas/src/torrent/actor.rs
@@ -628,7 +628,7 @@ mod tests {
       testing,
       torrent::{
          BLOCK_SIZE, Torrent, TorrentExport,
-         commands::{ExportState, HasInfoDict},
+         commands::{ExportState, GetState, HasInfoDict, SetState},
       },
    };
 
@@ -710,6 +710,90 @@ mod tests {
          }
          sleep(Duration::from_millis(100)).await;
       }
+
+      actor.stop_gracefully().await.expect("Failed to stop");
+   }
+
+   #[tokio::test(flavor = "multi_thread")]
+   async fn torrent_actor_when_metadata_is_ready_without_autostart_then_reports_ready() {
+      testing::init_tracing();
+      let metainfo = testing::read_torrent_fixture(testing::BIG_BUCK_BUNNY_TORRENT_FILE).await;
+
+      let actor = TorrentActor::spawn(TorrentActorArgs {
+         peer_id: testing::peer_id(),
+         metainfo,
+         utp_server: UtpSocket::new_udp(testing::ephemeral_socket_addr())
+            .await
+            .unwrap(),
+         tracker_server: testing::udp_server().await,
+         primary_addr: None,
+         piece_storage: PieceStorageStrategy::default(),
+         autostart: Some(false),
+         sufficient_peers: Some(0),
+         base_path: None,
+         settings: Settings::default(),
+      });
+
+      assert_eq!(actor.ask(GetState).await.unwrap(), TorrentState::Ready);
+
+      actor.stop_gracefully().await.expect("Failed to stop");
+   }
+
+   #[tokio::test(flavor = "multi_thread")]
+   async fn torrent_actor_when_metadata_is_missing_then_reports_resolving_metadata() {
+      testing::init_tracing();
+
+      let actor = TorrentActor::spawn(TorrentActorArgs {
+         peer_id: testing::peer_id(),
+         metainfo: testing::big_buck_bunny_magnet(),
+         utp_server: UtpSocket::new_udp(testing::ephemeral_socket_addr())
+            .await
+            .unwrap(),
+         tracker_server: testing::udp_server().await,
+         primary_addr: None,
+         piece_storage: PieceStorageStrategy::default(),
+         autostart: Some(false),
+         sufficient_peers: Some(0),
+         base_path: None,
+         settings: Settings::default(),
+      });
+
+      assert_eq!(
+         actor.ask(GetState).await.unwrap(),
+         TorrentState::ResolvingMetadata
+      );
+
+      actor.stop_gracefully().await.expect("Failed to stop");
+   }
+
+   #[tokio::test(flavor = "multi_thread")]
+   async fn torrent_actor_when_paused_then_does_not_report_ready() {
+      testing::init_tracing();
+      let metainfo = testing::read_torrent_fixture(testing::BIG_BUCK_BUNNY_TORRENT_FILE).await;
+
+      let actor = TorrentActor::spawn(TorrentActorArgs {
+         peer_id: testing::peer_id(),
+         metainfo,
+         utp_server: UtpSocket::new_udp(testing::ephemeral_socket_addr())
+            .await
+            .unwrap(),
+         tracker_server: testing::udp_server().await,
+         primary_addr: None,
+         piece_storage: PieceStorageStrategy::default(),
+         autostart: Some(false),
+         sufficient_peers: Some(0),
+         base_path: None,
+         settings: Settings::default(),
+      });
+
+      actor
+         .tell(SetState {
+            state: TorrentState::Paused,
+         })
+         .await
+         .unwrap();
+
+      assert_eq!(actor.ask(GetState).await.unwrap(), TorrentState::Paused);
 
       actor.stop_gracefully().await.expect("Failed to stop");
    }

--- a/crates/libtortillas/src/torrent/choking.rs
+++ b/crates/libtortillas/src/torrent/choking.rs
@@ -116,7 +116,13 @@ fn rate_for(peer: &PeerStats, torrent_state: TorrentState) -> usize {
    match torrent_state {
       TorrentState::Downloading => peer.download_rate,
       TorrentState::Seeding => peer.upload_rate,
-      TorrentState::Inactive => 0,
+      TorrentState::Added
+      | TorrentState::ResolvingMetadata
+      | TorrentState::Ready
+      | TorrentState::Paused
+      | TorrentState::Stopping
+      | TorrentState::Stopped
+      | TorrentState::Failed => 0,
    }
 }
 

--- a/crates/libtortillas/src/torrent/choking_flow.rs
+++ b/crates/libtortillas/src/torrent/choking_flow.rs
@@ -6,21 +6,15 @@ use tokio::time::timeout;
 use tracing::{trace, warn};
 
 use super::TorrentActor;
-use crate::{
-   peer::{
-      PeerActor, PeerStats,
-      commands::{SetChoked, Stats},
-   },
-   torrent::TorrentState,
+use crate::peer::{
+   PeerActor, PeerStats,
+   commands::{SetChoked, Stats},
 };
 
 impl TorrentActor {
    pub(super) async fn rechoke_peers(&mut self) {
-      if !matches!(
-         self.state,
-         TorrentState::Downloading | TorrentState::Seeding
-      ) {
-         trace!(state = ?self.state, "Skipping rechoke while torrent is inactive");
+      if !self.state.is_transfer_active() {
+         trace!(state = ?self.state, "Skipping rechoke while torrent is not transferring");
          return;
       }
 

--- a/crates/libtortillas/src/torrent/messages.rs
+++ b/crates/libtortillas/src/torrent/messages.rs
@@ -104,6 +104,9 @@ pub(crate) mod events {
             let info: Info = serde_bencode::from_bytes(&bytes).expect("Failed to parse info dict");
             self.bitfield = BitVec::repeat(false, info.piece_count());
             self.info = Some(info);
+            if self.state == TorrentState::ResolvingMetadata {
+               self.state = TorrentState::Added;
+            }
             self
                .broadcast_to_peers(HaveInfoDict {
                   bitfield: Arc::new(self.bitfield.clone()),
@@ -211,9 +214,15 @@ pub(crate) mod commands {
       /// pieces/seeding.
       #[message]
       pub(crate) async fn set_state(&mut self, state: TorrentState) {
-         self.state = state;
-         if let TorrentState::Downloading = state {
-            self.start().await;
+         match state {
+            TorrentState::Downloading => self.start().await,
+            TorrentState::Paused => {
+               if let Some(next_rechoke) = self.next_rechoke.take() {
+                  next_rechoke.abort();
+               }
+               self.state = TorrentState::Paused;
+            }
+            state => self.state = state,
          }
       }
 
@@ -246,9 +255,7 @@ pub(crate) mod commands {
       /// Only should be used internally.
       #[message]
       pub(crate) async fn ready_hook(&mut self, hook: ReadyHookSender) {
-         // If torrent has already transitioned from Inactive state, immediately send
-         // ready signal.
-         if self.state != TorrentState::Inactive {
+         if self.state == TorrentState::Ready || self.state.is_transfer_active() {
             let _ = hook.send(());
             return;
          }

--- a/crates/libtortillas/src/torrent/state.rs
+++ b/crates/libtortillas/src/torrent/state.rs
@@ -1,7 +1,13 @@
 use kameo::Reply;
 use serde::{Deserialize, Serialize};
 
-/// The current state of the torrent.
+/// The current lifecycle state of a torrent.
+///
+/// Expected transition shape:
+/// `Added` or `ResolvingMetadata` -> `Ready` -> `Downloading` -> `Seeding`.
+/// Future frontend commands may also move a torrent through `Paused`,
+/// `Stopping`, `Stopped`, or `Failed` without collapsing those states into a
+/// generic inactive bucket.
 #[derive(
    Debug,
    Default,
@@ -16,11 +22,44 @@ use serde::{Deserialize, Serialize};
    Reply
 )]
 pub enum TorrentState {
+   /// Torrent is registered but not ready to transfer yet.
+   #[default]
+   Added,
+   /// Torrent was added from a metadata source such as a magnet URI and is
+   /// waiting for the info dict before it can start.
+   ResolvingMetadata,
+   /// Torrent has enough metadata and peers to start, but autostart is off.
+   Ready,
    /// Torrent is downloading new pieces actively.
    Downloading,
+   /// Torrent is intentionally paused by a frontend or caller.
+   Paused,
    /// Torrent is seeding and has already completed the file.
    Seeding,
-   /// Torrent is paused or currently inactive.
-   #[default]
-   Inactive,
+   /// Torrent is shutting down actors, peers, or trackers.
+   Stopping,
+   /// Torrent has completed shutdown.
+   Stopped,
+   /// Torrent hit an unrecoverable runtime failure.
+   Failed,
+}
+
+impl TorrentState {
+   /// Returns `true` when peers should be rechoked and piece requests may flow.
+   pub const fn is_transfer_active(self) -> bool {
+      matches!(self, Self::Downloading | Self::Seeding)
+   }
+
+   /// Returns `true` when the torrent can transition to `Ready` or start.
+   pub const fn can_become_ready(self) -> bool {
+      matches!(self, Self::Added | Self::ResolvingMetadata | Self::Ready)
+   }
+
+   /// Returns `true` when `start` should attempt to enter active transfer.
+   pub const fn can_start(self) -> bool {
+      matches!(
+         self,
+         Self::Added | Self::ResolvingMetadata | Self::Ready | Self::Paused
+      )
+   }
 }

--- a/crates/libtortillas/src/torrent/state.rs
+++ b/crates/libtortillas/src/torrent/state.rs
@@ -63,3 +63,40 @@ impl TorrentState {
       )
    }
 }
+
+#[cfg(test)]
+mod tests {
+   use super::TorrentState;
+
+   #[test]
+   fn torrent_state_only_treats_transfer_states_as_active() {
+      assert!(TorrentState::Downloading.is_transfer_active());
+      assert!(TorrentState::Seeding.is_transfer_active());
+
+      assert!(!TorrentState::Added.is_transfer_active());
+      assert!(!TorrentState::Ready.is_transfer_active());
+      assert!(!TorrentState::Paused.is_transfer_active());
+      assert!(!TorrentState::Stopped.is_transfer_active());
+   }
+
+   #[test]
+   fn torrent_state_distinguishes_ready_candidates_from_paused_torrents() {
+      assert!(TorrentState::Added.can_become_ready());
+      assert!(TorrentState::ResolvingMetadata.can_become_ready());
+      assert!(TorrentState::Ready.can_become_ready());
+
+      assert!(!TorrentState::Paused.can_become_ready());
+      assert!(!TorrentState::Downloading.can_become_ready());
+      assert!(!TorrentState::Failed.can_become_ready());
+   }
+
+   #[test]
+   fn torrent_state_allows_manual_start_from_paused() {
+      assert!(TorrentState::Paused.can_start());
+
+      assert!(!TorrentState::Downloading.can_start());
+      assert!(!TorrentState::Seeding.can_start());
+      assert!(!TorrentState::Stopping.can_start());
+      assert!(!TorrentState::Stopped.can_start());
+   }
+}


### PR DESCRIPTION
## Summary
- replace the overloaded inactive torrent state with explicit frontend lifecycle states
- keep paused torrents distinct from ready/autostart candidates
- document lifecycle transitions and add actor/state coverage

Closes #243.
Part of #221.

## Tests
- cargo nextest run -p libtortillas torrent::choking
- cargo nextest run -p libtortillas torrent::state torrent::actor::tests::torrent_actor_when_metadata_is_ready_without_autostart_then_reports_ready torrent::actor::tests::torrent_actor_when_metadata_is_missing_then_reports_resolving_metadata torrent::actor::tests::torrent_actor_when_paused_then_does_not_report_ready
- cargo nextest run -p libtortillas torrent::state
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo nextest run --workspace

Ignored network tests were not run because the changes are limited to local lifecycle state handling and exported state semantics.