### PR TITLE
feat: add lifecycle commands

### DIFF
--- a/crates/libtortillas/src/engine/actor.rs
+++ b/crates/libtortillas/src/engine/actor.rs
@@ -224,4 +224,24 @@ impl Actor for EngineActor {
          },
       })
    }
+
+   async fn on_stop(
+      &mut self, _: WeakActorRef<Self>, _: ActorStopReason,
+   ) -> Result<(), Self::Error> {
+      let torrents = self
+         .torrents
+         .iter()
+         .map(|torrent| (*torrent.key(), torrent.value().clone()))
+         .collect::<Vec<_>>();
+
+      for (info_hash, torrent) in torrents {
+         if let Err(err) = torrent.stop_gracefully().await {
+            error!(error = %err, %info_hash, "Failed to stop torrent during engine shutdown");
+         }
+         torrent.wait_for_shutdown().await;
+         self.torrents.remove(&info_hash);
+      }
+
+      Ok(())
+   }
 }

--- a/crates/libtortillas/src/engine/messages.rs
+++ b/crates/libtortillas/src/engine/messages.rs
@@ -129,7 +129,7 @@ pub(crate) mod commands {
                settings: self.settings.clone(),
             },
          )
-         .restart_policy(RestartPolicy::Permanent)
+         .restart_policy(RestartPolicy::Transient)
          .restart_limit(
             self.settings.engine.torrent_restart.limit,
             self.settings.engine.torrent_restart.period,

--- a/crates/libtortillas/src/engine/messages.rs
+++ b/crates/libtortillas/src/engine/messages.rs
@@ -6,6 +6,7 @@ use tracing::{error, warn};
 use super::{EngineActor, EngineExport};
 use crate::{
    errors::EngineError,
+   hashes::InfoHash,
    metainfo::MetaInfo,
    peer::Peer,
    protocol::stream::{PeerStream, validate_handshake_protocol},
@@ -81,6 +82,18 @@ pub(crate) mod commands {
                warn!(error = %err, "Failed to start torrent");
             }
          }
+      }
+
+      /// Removes a torrent actor from the engine and stops it gracefully.
+      #[message]
+      pub(crate) async fn remove_torrent(
+         &mut self, info_hash: InfoHash,
+      ) -> Result<ActorRef<TorrentActor>, EngineError> {
+         let Some((_, torrent)) = self.torrents.remove(&info_hash) else {
+            return Err(EngineError::TorrentNotFound(info_hash));
+         };
+
+         Ok(torrent)
       }
 
       /// Creates a new [`Torrent`](crate::torrent::Torrent) actor.

--- a/crates/libtortillas/src/engine/mod.rs
+++ b/crates/libtortillas/src/engine/mod.rs
@@ -46,9 +46,10 @@ pub(crate) use messages::*;
 use serde::{Deserialize, Serialize};
 use tracing::error;
 
-use self::commands::{CreateTorrent, ExportEngine, StartAll};
+use self::commands::{CreateTorrent, ExportEngine, RemoveTorrent, StartAll};
 use crate::{
    errors::EngineError,
+   hashes::InfoHash,
    metainfo::{MetaInfo, TorrentFile},
    peer::PeerId,
    settings::Settings,
@@ -296,6 +297,34 @@ impl Engine {
          .tell(StartAll)
          .await
          .map_err(|e| EngineError::Other(anyhow::anyhow!(e.to_string())))?;
+      Ok(())
+   }
+
+   /// Removes a torrent from the engine and stops its actor gracefully.
+   pub async fn remove_torrent(&self, info_hash: InfoHash) -> Result<(), EngineError> {
+      let torrent = self
+         .actor()
+         .ask(RemoveTorrent { info_hash })
+         .await
+         .map_err(|e| EngineError::Other(anyhow::anyhow!(e.to_string())))?;
+
+      torrent
+         .stop_gracefully()
+         .await
+         .map_err(|e| EngineError::Other(anyhow::anyhow!(e.to_string())))?;
+
+      Ok(())
+   }
+
+   /// Gracefully shuts down the engine and its managed torrent actors.
+   pub async fn shutdown(&self) -> Result<(), EngineError> {
+      self
+         .actor()
+         .stop_gracefully()
+         .await
+         .map_err(|e| EngineError::Other(anyhow::anyhow!(e.to_string())))?;
+      self.actor().wait_for_shutdown().await;
+
       Ok(())
    }
 

--- a/crates/libtortillas/src/engine/mod.rs
+++ b/crates/libtortillas/src/engine/mod.rs
@@ -41,7 +41,10 @@ use std::{net::SocketAddr, path::PathBuf};
 
 pub(crate) use actor::*;
 use bon;
-use kameo::actor::{ActorRef, Spawn};
+use kameo::{
+   actor::{ActorRef, Spawn},
+   error::SendError,
+};
 pub(crate) use messages::*;
 use serde::{Deserialize, Serialize};
 use tracing::error;
@@ -302,16 +305,17 @@ impl Engine {
 
    /// Removes a torrent from the engine and stops its actor gracefully.
    pub async fn remove_torrent(&self, info_hash: InfoHash) -> Result<(), EngineError> {
-      let torrent = self
-         .actor()
-         .ask(RemoveTorrent { info_hash })
-         .await
-         .map_err(|e| EngineError::Other(anyhow::anyhow!(e.to_string())))?;
+      let torrent = match self.actor().ask(RemoveTorrent { info_hash }).await {
+         Ok(torrent) => torrent,
+         Err(SendError::HandlerError(err)) => return Err(err),
+         Err(err) => return Err(EngineError::Other(anyhow::anyhow!(err.to_string()))),
+      };
 
       torrent
          .stop_gracefully()
          .await
          .map_err(|e| EngineError::Other(anyhow::anyhow!(e.to_string())))?;
+      torrent.wait_for_shutdown().await;
 
       Ok(())
    }

--- a/crates/libtortillas/src/errors.rs
+++ b/crates/libtortillas/src/errors.rs
@@ -53,6 +53,10 @@ pub enum EngineError {
    #[error("Torrent already exists: {0}")]
    TorrentAlreadyExists(InfoHash),
 
+   /// Tried to operate on a torrent the engine does not manage.
+   #[error("Torrent not found: {0}")]
+   TorrentNotFound(InfoHash),
+
    /// Any other engine-level error wrapped in [`anyhow::Error`]
    #[error(transparent)]
    Other(#[from] anyhow::Error),

--- a/crates/libtortillas/src/facade.rs
+++ b/crates/libtortillas/src/facade.rs
@@ -70,8 +70,12 @@ pub enum CoreCommand {
    StartAll,
    /// Start one torrent.
    StartTorrent { torrent: InfoHash },
+   /// Resume one torrent.
+   ResumeTorrent { torrent: InfoHash },
    /// Pause one torrent.
    PauseTorrent { torrent: InfoHash },
+   /// Stop one torrent.
+   StopTorrent { torrent: InfoHash },
    /// Change the output folder for one torrent.
    SetTorrentOutputPath { torrent: InfoHash, path: PathBuf },
    /// Enable or disable autostart for one torrent.

--- a/crates/libtortillas/src/facade.rs
+++ b/crates/libtortillas/src/facade.rs
@@ -76,6 +76,10 @@ pub enum CoreCommand {
    PauseTorrent { torrent: InfoHash },
    /// Stop one torrent.
    StopTorrent { torrent: InfoHash },
+   /// Remove one torrent from the engine.
+   RemoveTorrent { torrent: InfoHash },
+   /// Gracefully shut down the engine.
+   Shutdown,
    /// Change the output folder for one torrent.
    SetTorrentOutputPath { torrent: InfoHash, path: PathBuf },
    /// Enable or disable autostart for one torrent.

--- a/crates/libtortillas/src/torrent/actor.rs
+++ b/crates/libtortillas/src/torrent/actor.rs
@@ -28,7 +28,7 @@ use crate::{
    errors::TorrentError,
    hashes::InfoHash,
    metainfo::{Info, MetaInfo},
-   peer::{PeerActor, PeerId},
+   peer::{PeerActor, PeerId, commands::SetChoked},
    pieces::{FilePieceManager, PieceManager, PieceScheduler, PieceStoreActor},
    settings::Settings,
    torrent::{BLOCK_SIZE, PieceStorageStrategy, TorrentExport, TorrentState},
@@ -191,6 +191,14 @@ impl TorrentActor {
    }
 
    pub async fn start(&mut self) {
+      if matches!(
+         self.state,
+         TorrentState::Downloading | TorrentState::Seeding
+      ) {
+         trace!(state = ?self.state, "Ignoring duplicate start request");
+         return;
+      }
+
       self.send_ready_hooks();
 
       let Some(info) = self.info.clone() else {
@@ -247,6 +255,34 @@ impl TorrentActor {
 
       self.rechoke_peers().await;
       self.schedule_next_rechoke().await;
+   }
+
+   pub async fn stop_transfer(&mut self) {
+      if !matches!(
+         self.state,
+         TorrentState::Downloading | TorrentState::Seeding
+      ) {
+         trace!(state = ?self.state, "Ignoring duplicate stop request");
+         return;
+      }
+
+      self.state = TorrentState::Inactive;
+      self.start_time = None;
+
+      if let Some(next_rechoke) = self.next_rechoke.take() {
+         next_rechoke.abort();
+      }
+
+      self.broadcast_to_peers(SetChoked { choked: true }).await;
+      self
+         .update_trackers(TrackerUpdate::Event(Event::Stopped))
+         .await;
+      self.broadcast_to_trackers(Announce).await;
+      self
+         .update_trackers(TrackerUpdate::Event(Event::Empty))
+         .await;
+
+      info!(id = %self.info_hash(), "Stopped torrenting process");
    }
 
    pub(super) async fn schedule_next_rechoke(&mut self) {
@@ -910,5 +946,84 @@ mod tests {
       trace!("Export: {export_str}");
 
       actor_ref.stop_gracefully().await.unwrap();
+   }
+
+   #[tokio::test(flavor = "multi_thread")]
+   async fn torrent_actor_when_stopped_then_returns_to_inactive_state() {
+      testing::init_tracing();
+      let metainfo = testing::read_torrent_fixture(testing::BIG_BUCK_BUNNY_TORRENT_FILE).await;
+      let info_dict = match &metainfo {
+         MetaInfo::Torrent(file) => file.info.clone(),
+         _ => unreachable!(),
+      };
+      let piece_count = info_dict.piece_count();
+
+      let peer_id = testing::peer_id();
+      let udp_server = testing::udp_server().await;
+      let utp_server = UtpSocket::new_udp(testing::ephemeral_socket_addr())
+         .await
+         .unwrap();
+      let piece_path = testing::torrent_temp_path();
+      let file_path = piece_path.join("files");
+
+      let actor_ref = TorrentActor::spawn(TorrentActorArgs {
+         peer_id,
+         metainfo: metainfo.clone(),
+         utp_server: utp_server.clone(),
+         tracker_server: udp_server.clone(),
+         primary_addr: None,
+         piece_storage: PieceStorageStrategy::Disk(piece_path.clone()),
+         autostart: Some(false),
+         sufficient_peers: Some(usize::MAX),
+         base_path: Some(file_path.clone()),
+         settings: Settings::default(),
+      });
+
+      let mut actor = TorrentActor {
+         peers: HashMap::new(),
+         trackers: HashMap::new(),
+         bitfield: BitVec::repeat(false, piece_count),
+         id: peer_id,
+         info: Some(info_dict.clone()),
+         metainfo,
+         tracker_server: udp_server,
+         scheduler: Scheduler::spawn(Scheduler::new()),
+         utp_server,
+         actor_ref: actor_ref.clone(),
+         piece_storage: PieceStorageStrategy::Disk(piece_path.clone()),
+         piece_store: PieceStoreActor::spawn(()),
+         piece_manager: PieceManagerProxy::Default(FilePieceManager(
+            Some(file_path),
+            Some(info_dict),
+         )),
+         state: TorrentState::Inactive,
+         piece_scheduler: PieceScheduler::new(piece_count),
+         choking_scheduler: ChokingScheduler::default(),
+         next_rechoke: None,
+         start_time: None,
+         sufficient_peers: 6,
+         autostart: false,
+         pending_start: false,
+         ready_hook: Vec::new(),
+         settings: Settings::default(),
+      };
+
+      actor.start().await;
+      assert_eq!(actor.state, TorrentState::Downloading);
+      assert!(actor.next_rechoke.is_some());
+
+      actor.start().await;
+      assert_eq!(actor.state, TorrentState::Downloading);
+
+      actor.stop_transfer().await;
+      assert_eq!(actor.state, TorrentState::Inactive);
+      assert!(actor.next_rechoke.is_none());
+
+      actor.stop_transfer().await;
+      assert_eq!(actor.state, TorrentState::Inactive);
+
+      actor_ref.stop_gracefully().await.unwrap();
+      actor.piece_store.kill();
+      actor.scheduler.kill();
    }
 }

--- a/crates/libtortillas/src/torrent/handle.rs
+++ b/crates/libtortillas/src/torrent/handle.rs
@@ -89,6 +89,38 @@ impl Torrent {
       Ok(())
    }
 
+   pub async fn resume(&self) -> Result<()> {
+      self.start().await
+   }
+
+   pub async fn pause(&self) -> Result<()> {
+      let msg = SetState {
+         state: TorrentState::Inactive,
+      };
+
+      self
+         .actor()
+         .tell(msg)
+         .await
+         .inspect_err(|e| error!(error = %e, "Failed to pause torrent"))?;
+
+      Ok(())
+   }
+
+   pub async fn stop(&self) -> Result<()> {
+      let msg = SetState {
+         state: TorrentState::Inactive,
+      };
+
+      self
+         .actor()
+         .tell(msg)
+         .await
+         .inspect_err(|e| error!(error = %e, "Failed to stop torrent"))?;
+
+      Ok(())
+   }
+
    pub async fn state(&self) -> Result<TorrentState> {
       Ok(self.actor().ask(GetState).await?)
    }

--- a/crates/libtortillas/src/torrent/handle.rs
+++ b/crates/libtortillas/src/torrent/handle.rs
@@ -76,47 +76,32 @@ impl Torrent {
    }
 
    pub async fn start(&self) -> Result<()> {
-      let msg = SetState {
-         state: TorrentState::Downloading,
-      };
-
-      self
-         .actor()
-         .tell(msg)
-         .await
-         .inspect_err(|e| error!(error = %e, "Failed to start torrent"))?;
-
-      Ok(())
+      self.set_state(TorrentState::Downloading, "start").await
    }
 
+   /// Resumes downloading or seeding this torrent.
    pub async fn resume(&self) -> Result<()> {
       self.start().await
    }
 
+   /// Pauses this torrent while preserving its downloaded data and metadata.
    pub async fn pause(&self) -> Result<()> {
-      let msg = SetState {
-         state: TorrentState::Inactive,
-      };
-
-      self
-         .actor()
-         .tell(msg)
-         .await
-         .inspect_err(|e| error!(error = %e, "Failed to pause torrent"))?;
-
-      Ok(())
+      self.set_state(TorrentState::Inactive, "pause").await
    }
 
+   /// Stops this torrent's active transfers.
    pub async fn stop(&self) -> Result<()> {
-      let msg = SetState {
-         state: TorrentState::Inactive,
-      };
+      self.set_state(TorrentState::Inactive, "stop").await
+   }
+
+   async fn set_state(&self, state: TorrentState, operation: &'static str) -> Result<()> {
+      let msg = SetState { state };
 
       self
          .actor()
-         .tell(msg)
+         .ask(msg)
          .await
-         .inspect_err(|e| error!(error = %e, "Failed to stop torrent"))?;
+         .inspect_err(|e| error!(error = %e, operation, "Failed to change torrent state"))?;
 
       Ok(())
    }

--- a/crates/libtortillas/src/torrent/messages.rs
+++ b/crates/libtortillas/src/torrent/messages.rs
@@ -211,9 +211,9 @@ pub(crate) mod commands {
       /// pieces/seeding.
       #[message]
       pub(crate) async fn set_state(&mut self, state: TorrentState) {
-         self.state = state;
-         if let TorrentState::Downloading = state {
-            self.start().await;
+         match state {
+            TorrentState::Downloading | TorrentState::Seeding => self.start().await,
+            TorrentState::Inactive => self.stop_transfer().await,
          }
       }
 

--- a/crates/libtortillas/tests/engine_lifecycle.rs
+++ b/crates/libtortillas/tests/engine_lifecycle.rs
@@ -7,6 +7,7 @@ use std::{
 
 use libtortillas::{
    engine::Engine,
+   errors::EngineError,
    hashes::{Hash, HashVec, InfoHash},
    metainfo::{Info, InfoKeys, TorrentFile},
    settings::Settings,
@@ -30,9 +31,13 @@ async fn engine_remove_torrent_drops_it_from_exports() {
 
    engine.remove_torrent(info_hash).await.unwrap();
    assert!(engine.export().await.unwrap().torrents.is_empty());
+   assert!(torrent.state().await.is_err());
 
    let err = engine.remove_torrent(info_hash).await.unwrap_err();
-   assert!(err.to_string().contains("Torrent not found"));
+   assert!(matches!(
+      err,
+      EngineError::TorrentNotFound(missing_hash) if missing_hash == info_hash
+   ));
 
    engine.shutdown().await.unwrap();
    let _ = fs::remove_file(path).await;

--- a/crates/libtortillas/tests/engine_lifecycle.rs
+++ b/crates/libtortillas/tests/engine_lifecycle.rs
@@ -1,0 +1,103 @@
+use std::{
+   env,
+   path::PathBuf,
+   process,
+   time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use libtortillas::{
+   engine::Engine,
+   hashes::{Hash, HashVec, InfoHash},
+   metainfo::{Info, InfoKeys, TorrentFile},
+   settings::Settings,
+   tracker::Tracker,
+};
+use tokio::fs;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn engine_remove_torrent_drops_it_from_exports() {
+   let (path, info_hash) = write_http_torrent_fixture().await;
+   let engine = Engine::builder()
+      .settings(test_settings())
+      .autostart(false)
+      .sufficient_peers(usize::MAX)
+      .build();
+
+   let torrent = engine.add_torrent(path.to_string_lossy()).await.unwrap();
+   assert_eq!(torrent.info_hash(), info_hash);
+   assert_eq!(engine.export().await.unwrap().torrents.len(), 1);
+
+   engine.remove_torrent(info_hash).await.unwrap();
+   assert!(engine.export().await.unwrap().torrents.is_empty());
+
+   let err = engine.remove_torrent(info_hash).await.unwrap_err();
+   assert!(err.to_string().contains("Torrent not found"));
+
+   engine.shutdown().await.unwrap();
+   let _ = fs::remove_file(path).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn engine_shutdown_stops_managed_torrents() {
+   let (path, _) = write_http_torrent_fixture().await;
+   let engine = Engine::builder()
+      .settings(test_settings())
+      .autostart(false)
+      .sufficient_peers(usize::MAX)
+      .build();
+
+   let torrent = engine.add_torrent(path.to_string_lossy()).await.unwrap();
+
+   engine.shutdown().await.unwrap();
+   assert!(torrent.state().await.is_err());
+
+   let _ = fs::remove_file(path).await;
+}
+
+fn test_settings() -> Settings {
+   let mut settings = Settings::default();
+   settings.tracker.stop_timeout = Duration::from_millis(20);
+   settings.tracker.http_stop_timeout = Duration::from_millis(20);
+   settings
+}
+
+async fn write_http_torrent_fixture() -> (PathBuf, InfoHash) {
+   let mut pieces = HashVec::new();
+   pieces.push(Hash::from_bytes([1; 20]));
+   let info = Info {
+      name: "engine-lifecycle.bin".to_string(),
+      piece_length: 16,
+      pieces,
+      file: InfoKeys::Single {
+         length: 16,
+         md5sum: None,
+      },
+      is_private: None,
+      publisher: None,
+      publisher_url: None,
+      source: None,
+   };
+   let torrent = TorrentFile {
+      announce: Tracker::Http("http://127.0.0.1:9/announce".to_string()),
+      announce_list: None,
+      comment: None,
+      created_by: Some("libtortillas-test".to_string()),
+      creation_date: None,
+      encoding: None,
+      info,
+      url_list: None,
+   };
+   let info_hash = torrent.info.hash().unwrap();
+   let bytes = serde_bencode::to_bytes(&torrent).unwrap();
+   let path = env::temp_dir().join(format!(
+      "tortillas-engine-lifecycle-{}-{}.torrent",
+      process::id(),
+      SystemTime::now()
+         .duration_since(UNIX_EPOCH)
+         .unwrap()
+         .as_nanos()
+   ));
+
+   fs::write(&path, bytes).await.unwrap();
+   (path, info_hash)
+}

--- a/crates/libtortillas/tests/engine_lifecycle.rs
+++ b/crates/libtortillas/tests/engine_lifecycle.rs
@@ -10,6 +10,7 @@ use libtortillas::{
    hashes::{Hash, HashVec, InfoHash},
    metainfo::{Info, InfoKeys, TorrentFile},
    settings::Settings,
+   torrent::TorrentState,
    tracker::Tracker,
 };
 use tokio::fs;
@@ -51,6 +52,32 @@ async fn engine_shutdown_stops_managed_torrents() {
    engine.shutdown().await.unwrap();
    assert!(torrent.state().await.is_err());
 
+   let _ = fs::remove_file(path).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn torrent_controls_complete_their_state_transitions() {
+   let (path, _) = write_http_torrent_fixture().await;
+   let engine = Engine::builder()
+      .settings(test_settings())
+      .autostart(false)
+      .sufficient_peers(usize::MAX)
+      .build();
+   let torrent = engine.add_torrent(path.to_string_lossy()).await.unwrap();
+
+   torrent.resume().await.unwrap();
+   assert_eq!(torrent.state().await.unwrap(), TorrentState::Downloading);
+
+   torrent.pause().await.unwrap();
+   assert_eq!(torrent.state().await.unwrap(), TorrentState::Inactive);
+   torrent.pause().await.unwrap();
+
+   torrent.resume().await.unwrap();
+   torrent.stop().await.unwrap();
+   assert_eq!(torrent.state().await.unwrap(), TorrentState::Inactive);
+   torrent.stop().await.unwrap();
+
+   engine.shutdown().await.unwrap();
    let _ = fs::remove_file(path).await;
 }
 

--- a/crates/libtortillas/tests/facade.rs
+++ b/crates/libtortillas/tests/facade.rs
@@ -46,6 +46,12 @@ fn command_variants_identify_torrents_by_info_hash() {
 
    let command = CoreCommand::StopTorrent { torrent };
    assert_eq!(command, CoreCommand::StopTorrent { torrent });
+
+   let command = CoreCommand::RemoveTorrent { torrent };
+   assert_eq!(command, CoreCommand::RemoveTorrent { torrent });
+
+   let command = CoreCommand::Shutdown;
+   assert_eq!(command, CoreCommand::Shutdown);
 }
 
 #[test]

--- a/crates/libtortillas/tests/facade.rs
+++ b/crates/libtortillas/tests/facade.rs
@@ -37,6 +37,15 @@ fn command_variants_identify_torrents_by_info_hash() {
    let command = CoreCommand::StartTorrent { torrent };
 
    assert_eq!(command, CoreCommand::StartTorrent { torrent });
+
+   let command = CoreCommand::PauseTorrent { torrent };
+   assert_eq!(command, CoreCommand::PauseTorrent { torrent });
+
+   let command = CoreCommand::ResumeTorrent { torrent };
+   assert_eq!(command, CoreCommand::ResumeTorrent { torrent });
+
+   let command = CoreCommand::StopTorrent { torrent };
+   assert_eq!(command, CoreCommand::StopTorrent { torrent });
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add public torrent pause, resume, and stop controls backed by idempotent actor lifecycle transitions
- add engine remove and graceful shutdown commands for frontend control
- cover lifecycle behavior with deterministic actor and engine tests

## Stack
- Stacked on #247 because #225 depends on the frontend facade from #222.

Closes #225.
Part of #221.

## Tests
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo nextest run --workspace
- cargo nextest run --workspace --run-ignored only
- cargo test -p libtortillas --doc