### PR TITLE
refactor: expose frontend snapshots from exports

### DIFF
--- a/crates/libtortillas/src/engine/messages.rs
+++ b/crates/libtortillas/src/engine/messages.rs
@@ -3,7 +3,7 @@ use kameo::{actor::Spawn, mailbox, messages, prelude::ActorRef, supervision::Res
 use tokio::time::timeout;
 use tracing::{error, warn};
 
-use super::{EngineActor, EngineExport};
+use super::{EngineActor, EngineExport, EngineSnapshot, EngineStatus};
 use crate::{
    errors::EngineError,
    metainfo::MetaInfo,
@@ -160,6 +160,35 @@ pub(crate) mod commands {
          let torrents = try_join_all(futures).await?;
 
          Ok(EngineExport { torrents })
+      }
+
+      /// Snapshots the current state of the engine for frontends.
+      #[message]
+      pub(crate) async fn snapshot_engine(&self) -> Result<EngineSnapshot, EngineError> {
+         let futures = self
+            .torrents
+            .iter()
+            .map(|torrent| {
+               let torrent = torrent.clone();
+               async move {
+                  torrent
+                     .ask(torrent::commands::SnapshotState)
+                     .await
+                     .map(|snapshot| *snapshot)
+                     .map_err(|err| {
+                        EngineError::Other(anyhow!("failed to get torrent snapshot: {err}"))
+                     })
+               }
+            })
+            .collect::<Vec<_>>();
+
+         let torrents = try_join_all(futures).await?;
+
+         Ok(EngineSnapshot {
+            status: EngineStatus::Running,
+            torrent_count: torrents.len(),
+            torrents,
+         })
       }
    }
 }

--- a/crates/libtortillas/src/engine/messages.rs
+++ b/crates/libtortillas/src/engine/messages.rs
@@ -161,7 +161,7 @@ pub(crate) mod commands {
 
          Ok(EngineSnapshot {
             status: EngineStatus::Running,
-            torrent_count: torrents.len(),
+            torrent_count: u64::try_from(torrents.len()).unwrap_or(u64::MAX),
             torrents,
          })
       }

--- a/crates/libtortillas/src/engine/messages.rs
+++ b/crates/libtortillas/src/engine/messages.rs
@@ -3,7 +3,7 @@ use kameo::{actor::Spawn, mailbox, messages, prelude::ActorRef, supervision::Res
 use tokio::time::timeout;
 use tracing::{error, warn};
 
-use super::{EngineActor, EngineExport, EngineSnapshot, EngineStatus};
+use super::{EngineActor, EngineSnapshot, EngineStatus};
 use crate::{
    errors::EngineError,
    metainfo::MetaInfo,
@@ -135,31 +135,6 @@ pub(crate) mod commands {
 
          self.torrents.insert(info_hash, torrent_ref.clone());
          Ok(torrent_ref)
-      }
-
-      /// Exports the current state of the engine.
-      #[message]
-      pub(crate) async fn export_engine(&self) -> Result<EngineExport, EngineError> {
-         let futures = self
-            .torrents
-            .iter()
-            .map(|torrent| {
-               let torrent = torrent.clone();
-               async move {
-                  torrent
-                     .ask(torrent::commands::ExportState)
-                     .await
-                     .map(|export| *export)
-                     .map_err(|err| {
-                        EngineError::Other(anyhow!("failed to get torrent export: {err}"))
-                     })
-               }
-            })
-            .collect::<Vec<_>>();
-
-         let torrents = try_join_all(futures).await?;
-
-         Ok(EngineExport { torrents })
       }
 
       /// Snapshots the current state of the engine for frontends.

--- a/crates/libtortillas/src/engine/mod.rs
+++ b/crates/libtortillas/src/engine/mod.rs
@@ -44,17 +44,16 @@ pub(crate) use actor::*;
 use bon;
 use kameo::actor::{ActorRef, Spawn};
 pub(crate) use messages::*;
-use serde::{Deserialize, Serialize};
 use tracing::error;
 
-use self::commands::{CreateTorrent, ExportEngine, SnapshotEngine, StartAll};
+use self::commands::{CreateTorrent, SnapshotEngine, StartAll};
 pub use self::snapshot::{EngineSnapshot, EngineStatus};
 use crate::{
    errors::EngineError,
    metainfo::{MetaInfo, TorrentFile},
    peer::PeerId,
    settings::Settings,
-   torrent::{PieceStorageStrategy, Torrent, TorrentExport},
+   torrent::{PieceStorageStrategy, Torrent},
 };
 
 /// The main entry point for managing torrents.
@@ -301,14 +300,9 @@ impl Engine {
       Ok(())
    }
 
-   /// Exports the current state of the engine.
-   /// See [`Torrent::export`] for more information.
-   pub async fn export(&self) -> Result<EngineExport, EngineError> {
-      self
-         .actor()
-         .ask(ExportEngine)
-         .await
-         .map_err(|e| EngineError::Other(anyhow::anyhow!(e.to_string())))
+   /// Exports the current engine state with frontend-ready torrent snapshots.
+   pub async fn export(&self) -> Result<EngineSnapshot, EngineError> {
+      self.snapshot().await
    }
 
    /// Snapshots the current engine state with frontend-ready torrent views.
@@ -325,11 +319,6 @@ impl Default for Engine {
    fn default() -> Self {
       Self::builder().build()
    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct EngineExport {
-   pub torrents: Vec<TorrentExport>,
 }
 
 #[cfg(test)]

--- a/crates/libtortillas/src/engine/mod.rs
+++ b/crates/libtortillas/src/engine/mod.rs
@@ -36,6 +36,7 @@
 
 mod actor;
 mod messages;
+mod snapshot;
 
 use std::{net::SocketAddr, path::PathBuf};
 
@@ -46,7 +47,8 @@ pub(crate) use messages::*;
 use serde::{Deserialize, Serialize};
 use tracing::error;
 
-use self::commands::{CreateTorrent, ExportEngine, StartAll};
+use self::commands::{CreateTorrent, ExportEngine, SnapshotEngine, StartAll};
+pub use self::snapshot::{EngineSnapshot, EngineStatus};
 use crate::{
    errors::EngineError,
    metainfo::{MetaInfo, TorrentFile},
@@ -308,6 +310,15 @@ impl Engine {
          .await
          .map_err(|e| EngineError::Other(anyhow::anyhow!(e.to_string())))
    }
+
+   /// Snapshots the current engine state with frontend-ready torrent views.
+   pub async fn snapshot(&self) -> Result<EngineSnapshot, EngineError> {
+      self
+         .actor()
+         .ask(SnapshotEngine)
+         .await
+         .map_err(|e| EngineError::Other(anyhow::anyhow!(e.to_string())))
+   }
 }
 
 impl Default for Engine {
@@ -319,4 +330,37 @@ impl Default for Engine {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EngineExport {
    pub torrents: Vec<TorrentExport>,
+}
+
+#[cfg(test)]
+mod tests {
+   use serde_json::{from_str, to_string};
+
+   use super::*;
+   use crate::testing;
+
+   #[tokio::test]
+   async fn engine_when_torrent_is_added_then_snapshots_frontend_state() {
+      let engine = Engine::default();
+      let torrent_path = testing::torrent_fixture_path(testing::BIG_BUCK_BUNNY_TORRENT_FILE);
+
+      let torrent = engine
+         .add_torrent(torrent_path.to_string_lossy())
+         .await
+         .unwrap();
+      let snapshot = engine.snapshot().await.unwrap();
+
+      assert_eq!(snapshot.status, EngineStatus::Running);
+      assert_eq!(snapshot.torrent_count, 1);
+      assert_eq!(snapshot.torrents.len(), 1);
+      assert_eq!(snapshot.torrents[0].info_hash, torrent.info_hash());
+      assert_eq!(snapshot.torrents[0].name, testing::BIG_BUCK_BUNNY_NAME);
+      assert!(snapshot.torrents[0].progress.total_pieces > 0);
+      assert!(snapshot.torrents[0].has_metadata);
+
+      let snapshot_str = to_string(&snapshot).unwrap();
+      let from_snapshot: EngineSnapshot = from_str(&snapshot_str).unwrap();
+
+      assert_eq!(snapshot, from_snapshot);
+   }
 }

--- a/crates/libtortillas/src/engine/snapshot.rs
+++ b/crates/libtortillas/src/engine/snapshot.rs
@@ -6,7 +6,7 @@ use crate::torrent::TorrentSnapshot;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EngineSnapshot {
    pub status: EngineStatus,
-   pub torrent_count: usize,
+   pub torrent_count: u64,
    pub torrents: Vec<TorrentSnapshot>,
 }
 

--- a/crates/libtortillas/src/engine/snapshot.rs
+++ b/crates/libtortillas/src/engine/snapshot.rs
@@ -1,0 +1,17 @@
+use serde::{Deserialize, Serialize};
+
+use crate::torrent::TorrentSnapshot;
+
+/// Stable, frontend-ready view of the engine.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EngineSnapshot {
+   pub status: EngineStatus,
+   pub torrent_count: usize,
+   pub torrents: Vec<TorrentSnapshot>,
+}
+
+/// Coarse engine status for frontend displays.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EngineStatus {
+   Running,
+}

--- a/crates/libtortillas/src/torrent/actor.rs
+++ b/crates/libtortillas/src/torrent/actor.rs
@@ -400,7 +400,7 @@ impl TorrentActor {
          name: self.display_name().to_string(),
          state: self.state,
          has_metadata: info.is_some(),
-         is_ready: self.is_ready(),
+         is_ready: self.state == TorrentState::Ready && self.is_ready(),
          auto_start: self.autostart,
          sufficient_peers: self.sufficient_peers,
          peer_count: self.peers.len(),
@@ -1122,7 +1122,7 @@ mod tests {
       let mut piece_scheduler = PieceScheduler::new(piece_count);
       piece_scheduler.set_piece_blocks(partial_piece_index, blocks);
 
-      let test_actor = TorrentActor {
+      let mut test_actor = TorrentActor {
          peers: HashMap::new(),
          trackers: HashMap::new(),
          bitfield,
@@ -1139,12 +1139,12 @@ mod tests {
             Some(file_path.clone()),
             Some(info_dict.clone()),
          )),
-         state: TorrentState::Inactive,
+         state: TorrentState::Ready,
          piece_scheduler,
          choking_scheduler: ChokingScheduler::default(),
          next_rechoke: None,
          start_time: None,
-         sufficient_peers: 6,
+         sufficient_peers: 0,
          autostart: false,
          pending_start: false,
          ready_hook: Vec::new(),
@@ -1155,10 +1155,11 @@ mod tests {
 
       assert_eq!(snapshot.info_hash, info_hash);
       assert_eq!(snapshot.name, testing::BIG_BUCK_BUNNY_NAME);
-      assert_eq!(snapshot.state, TorrentState::Inactive);
+      assert_eq!(snapshot.state, TorrentState::Ready);
       assert!(snapshot.has_metadata);
+      assert!(snapshot.is_ready);
       assert!(!snapshot.auto_start);
-      assert_eq!(snapshot.sufficient_peers, 6);
+      assert_eq!(snapshot.sufficient_peers, 0);
       assert_eq!(snapshot.output_path, Some(file_path));
       assert_eq!(
          snapshot.progress.total_bytes,
@@ -1178,6 +1179,9 @@ mod tests {
       let from_snapshot: TorrentSnapshot = serde_json::from_str(&snapshot_str).unwrap();
 
       assert_eq!(snapshot, from_snapshot);
+
+      test_actor.state = TorrentState::Paused;
+      assert!(!test_actor.snapshot().is_ready);
 
       actor_ref.stop_gracefully().await.unwrap();
    }

--- a/crates/libtortillas/src/torrent/actor.rs
+++ b/crates/libtortillas/src/torrent/actor.rs
@@ -372,8 +372,8 @@ impl TorrentActor {
 
    pub fn snapshot(&self) -> TorrentSnapshot {
       let info = self.info_dict();
-      let total_bytes = info.map(Info::total_length);
-      let downloaded_bytes = self.total_bytes_downloaded().unwrap_or(0);
+      let total_bytes = info.map(Info::total_length).map(Self::snapshot_u64);
+      let downloaded_bytes = Self::snapshot_u64(self.total_bytes_downloaded().unwrap_or(0));
       let bytes_remaining =
          total_bytes.map(|bytes| bytes.saturating_sub(downloaded_bytes.min(bytes)));
       let progress_fraction = total_bytes.map(|bytes| {
@@ -402,9 +402,9 @@ impl TorrentActor {
          has_metadata: info.is_some(),
          is_ready: self.state == TorrentState::Ready && self.is_ready(),
          auto_start: self.autostart,
-         sufficient_peers: self.sufficient_peers,
-         peer_count: self.peers.len(),
-         tracker_count: self.trackers.len(),
+         sufficient_peers: Self::snapshot_u64(self.sufficient_peers),
+         peer_count: Self::snapshot_u64(self.peers.len()),
+         tracker_count: Self::snapshot_u64(self.trackers.len()),
          output_path: match &self.piece_manager {
             PieceManagerProxy::Default(manager) => manager.path().cloned(),
             PieceManagerProxy::Custom(_) => None,
@@ -414,9 +414,9 @@ impl TorrentActor {
             downloaded_bytes,
             bytes_remaining,
             progress_fraction,
-            completed_pieces,
-            partial_pieces,
-            total_pieces,
+            completed_pieces: Self::snapshot_u64(completed_pieces),
+            partial_pieces: Self::snapshot_u64(partial_pieces),
+            total_pieces: Self::snapshot_u64(total_pieces),
          },
          transfer: TorrentTransferSnapshot {
             download_rate_bytes_per_second: None,
@@ -424,6 +424,10 @@ impl TorrentActor {
             eta_seconds: None,
          },
       }
+   }
+
+   fn snapshot_u64(value: usize) -> u64 {
+      u64::try_from(value).unwrap_or(u64::MAX)
    }
 
    fn display_name(&self) -> &str {
@@ -1163,13 +1167,22 @@ mod tests {
       assert_eq!(snapshot.output_path, Some(file_path));
       assert_eq!(
          snapshot.progress.total_bytes,
-         Some(info_dict.total_length())
+         Some(u64::try_from(info_dict.total_length()).unwrap())
       );
-      assert_eq!(snapshot.progress.completed_pieces, completed_pieces);
+      assert_eq!(
+         snapshot.progress.completed_pieces,
+         u64::try_from(completed_pieces).unwrap()
+      );
       assert_eq!(snapshot.progress.partial_pieces, 1);
-      assert_eq!(snapshot.progress.total_pieces, piece_count);
+      assert_eq!(
+         snapshot.progress.total_pieces,
+         u64::try_from(piece_count).unwrap()
+      );
       assert!(snapshot.progress.downloaded_bytes > 0);
-      assert!(snapshot.progress.bytes_remaining.unwrap() < info_dict.total_length());
+      assert!(
+         snapshot.progress.bytes_remaining.unwrap()
+            < u64::try_from(info_dict.total_length()).unwrap()
+      );
       assert!(snapshot.progress.progress_fraction.unwrap() > 0.0);
       assert_eq!(snapshot.transfer.download_rate_bytes_per_second, None);
       assert_eq!(snapshot.transfer.upload_rate_bytes_per_second, None);

--- a/crates/libtortillas/src/torrent/actor.rs
+++ b/crates/libtortillas/src/torrent/actor.rs
@@ -31,7 +31,10 @@ use crate::{
    peer::{PeerActor, PeerId},
    pieces::{FilePieceManager, PieceManager, PieceScheduler, PieceStoreActor},
    settings::Settings,
-   torrent::{BLOCK_SIZE, PieceStorageStrategy, TorrentExport, TorrentState},
+   torrent::{
+      BLOCK_SIZE, PieceStorageStrategy, TorrentExport, TorrentProgressSnapshot, TorrentSnapshot,
+      TorrentState, TorrentTransferSnapshot,
+   },
    tracker::{
       Announce, Event, Tracker, TrackerActor, TrackerActorArgs, TrackerUpdate, udp::UdpServer,
    },
@@ -367,6 +370,69 @@ impl TorrentActor {
       }
    }
 
+   pub fn snapshot(&self) -> TorrentSnapshot {
+      let info = self.info_dict();
+      let total_bytes = info.map(Info::total_length);
+      let downloaded_bytes = self.total_bytes_downloaded().unwrap_or(0);
+      let bytes_remaining =
+         total_bytes.map(|bytes| bytes.saturating_sub(downloaded_bytes.min(bytes)));
+      let progress_fraction = total_bytes.map(|bytes| {
+         if bytes == 0 {
+            1.0
+         } else {
+            downloaded_bytes.min(bytes) as f64 / bytes as f64
+         }
+      });
+      let completed_pieces = self.bitfield.count_ones();
+      let total_pieces = self.bitfield.len();
+      let partial_pieces = self
+         .piece_scheduler
+         .block_map_export()
+         .iter()
+         .filter(|entry| {
+            let piece_idx = *entry.key();
+            piece_idx < total_pieces && !self.bitfield[piece_idx] && entry.value().count_ones() > 0
+         })
+         .count();
+
+      TorrentSnapshot {
+         info_hash: self.info_hash(),
+         name: self.display_name().to_string(),
+         state: self.state,
+         has_metadata: info.is_some(),
+         is_ready: self.is_ready(),
+         auto_start: self.autostart,
+         sufficient_peers: self.sufficient_peers,
+         peer_count: self.peers.len(),
+         tracker_count: self.trackers.len(),
+         output_path: match &self.piece_manager {
+            PieceManagerProxy::Default(manager) => manager.path().cloned(),
+            PieceManagerProxy::Custom(_) => None,
+         },
+         progress: TorrentProgressSnapshot {
+            total_bytes,
+            downloaded_bytes,
+            bytes_remaining,
+            progress_fraction,
+            completed_pieces,
+            partial_pieces,
+            total_pieces,
+         },
+         transfer: TorrentTransferSnapshot {
+            download_rate_bytes_per_second: None,
+            upload_rate_bytes_per_second: None,
+            eta_seconds: None,
+         },
+      }
+   }
+
+   fn display_name(&self) -> &str {
+      match &self.metainfo {
+         MetaInfo::Torrent(torrent) => &torrent.info.name,
+         MetaInfo::MagnetUri(magnet) => &magnet.name,
+      }
+   }
+
    pub fn is_full(&self) -> bool {
       self.bitfield.count_ones() == self.bitfield.len()
    }
@@ -627,7 +693,7 @@ mod tests {
       settings::Settings,
       testing,
       torrent::{
-         BLOCK_SIZE, Torrent, TorrentExport,
+         BLOCK_SIZE, Torrent, TorrentExport, TorrentSnapshot,
          commands::{ExportState, GetState, HasInfoDict, SetState},
       },
    };
@@ -1003,6 +1069,115 @@ mod tests {
       assert_eq!(export.block_map.len(), from_export.block_map.len());
 
       trace!("Export: {export_str}");
+
+      actor_ref.stop_gracefully().await.unwrap();
+   }
+
+   #[tokio::test(flavor = "multi_thread")]
+   async fn torrent_actor_when_pieces_are_marked_complete_then_snapshots_progress_correctly() {
+      testing::init_tracing();
+      let metainfo = testing::read_torrent_fixture(testing::BIG_BUCK_BUNNY_TORRENT_FILE).await;
+      let info_dict = match &metainfo {
+         MetaInfo::Torrent(file) => file.info.clone(),
+         _ => unreachable!(),
+      };
+      let info_hash = info_dict.hash().unwrap();
+
+      let piece_path = testing::torrent_temp_path();
+      let file_path = piece_path.join("files");
+
+      let peer_id = testing::peer_id();
+      let udp_server = testing::udp_server().await;
+      let utp_server = UtpSocket::new_udp(testing::ephemeral_socket_addr())
+         .await
+         .unwrap();
+
+      let actor_ref = TorrentActor::spawn(TorrentActorArgs {
+         peer_id,
+         metainfo: metainfo.clone(),
+         utp_server: utp_server.clone(),
+         tracker_server: udp_server.clone(),
+         primary_addr: None,
+         piece_storage: PieceStorageStrategy::Disk(piece_path),
+         autostart: Some(false),
+         sufficient_peers: Some(usize::MAX),
+         base_path: Some(file_path.clone()),
+         settings: Settings::default(),
+      });
+
+      let piece_count = info_dict.piece_count();
+      let bitfield: BitVec<AtomicU8> = BitVec::repeat(false, piece_count);
+      let completed_pieces = 3;
+      for index in 0..completed_pieces {
+         bitfield.set_aliased(index, true);
+      }
+
+      let partial_piece_index = completed_pieces;
+      let total_blocks = (info_dict.piece_length as usize).div_ceil(BLOCK_SIZE);
+      let mut blocks = BitVec::<usize>::repeat(false, total_blocks);
+      let partial_blocks_received = 2;
+      for index in 0..partial_blocks_received {
+         blocks.set(index, true);
+      }
+      let mut piece_scheduler = PieceScheduler::new(piece_count);
+      piece_scheduler.set_piece_blocks(partial_piece_index, blocks);
+
+      let test_actor = TorrentActor {
+         peers: HashMap::new(),
+         trackers: HashMap::new(),
+         bitfield,
+         id: peer_id,
+         info: Some(info_dict.clone()),
+         metainfo: metainfo.clone(),
+         tracker_server: udp_server,
+         scheduler: Scheduler::spawn(Scheduler::new()),
+         utp_server,
+         actor_ref: actor_ref.clone(),
+         piece_storage: PieceStorageStrategy::InFile,
+         piece_store: PieceStoreActor::spawn(()),
+         piece_manager: PieceManagerProxy::Default(FilePieceManager(
+            Some(file_path.clone()),
+            Some(info_dict.clone()),
+         )),
+         state: TorrentState::Inactive,
+         piece_scheduler,
+         choking_scheduler: ChokingScheduler::default(),
+         next_rechoke: None,
+         start_time: None,
+         sufficient_peers: 6,
+         autostart: false,
+         pending_start: false,
+         ready_hook: Vec::new(),
+         settings: Settings::default(),
+      };
+
+      let snapshot = test_actor.snapshot();
+
+      assert_eq!(snapshot.info_hash, info_hash);
+      assert_eq!(snapshot.name, testing::BIG_BUCK_BUNNY_NAME);
+      assert_eq!(snapshot.state, TorrentState::Inactive);
+      assert!(snapshot.has_metadata);
+      assert!(!snapshot.auto_start);
+      assert_eq!(snapshot.sufficient_peers, 6);
+      assert_eq!(snapshot.output_path, Some(file_path));
+      assert_eq!(
+         snapshot.progress.total_bytes,
+         Some(info_dict.total_length())
+      );
+      assert_eq!(snapshot.progress.completed_pieces, completed_pieces);
+      assert_eq!(snapshot.progress.partial_pieces, 1);
+      assert_eq!(snapshot.progress.total_pieces, piece_count);
+      assert!(snapshot.progress.downloaded_bytes > 0);
+      assert!(snapshot.progress.bytes_remaining.unwrap() < info_dict.total_length());
+      assert!(snapshot.progress.progress_fraction.unwrap() > 0.0);
+      assert_eq!(snapshot.transfer.download_rate_bytes_per_second, None);
+      assert_eq!(snapshot.transfer.upload_rate_bytes_per_second, None);
+      assert_eq!(snapshot.transfer.eta_seconds, None);
+
+      let snapshot_str = serde_json::to_string(&snapshot).unwrap();
+      let from_snapshot: TorrentSnapshot = serde_json::from_str(&snapshot_str).unwrap();
+
+      assert_eq!(snapshot, from_snapshot);
 
       actor_ref.stop_gracefully().await.unwrap();
    }

--- a/crates/libtortillas/src/torrent/handle.rs
+++ b/crates/libtortillas/src/torrent/handle.rs
@@ -6,10 +6,10 @@ use tokio::sync::oneshot;
 use tracing::error;
 
 use super::{
-   PieceStorageStrategy, TorrentActor, TorrentExport, TorrentSnapshot, TorrentState,
+   PieceStorageStrategy, TorrentActor, TorrentSnapshot, TorrentState,
    commands::{
-      ExportState, GetState, ReadyHook, SetAutoStart, SetOutputPath, SetPieceManager,
-      SetPieceStorage, SetState, SetSufficientPeers, SnapshotState,
+      GetState, ReadyHook, SetAutoStart, SetOutputPath, SetPieceManager, SetPieceStorage, SetState,
+      SetSufficientPeers, SnapshotState,
    },
 };
 use crate::{hashes::InfoHash, pieces::PieceManager};
@@ -93,8 +93,9 @@ impl Torrent {
       Ok(self.actor().ask(GetState).await?)
    }
 
-   pub async fn export(&self) -> Result<TorrentExport> {
-      Ok(*self.actor().ask(ExportState).await?)
+   /// Returns a stable, frontend-ready snapshot of this torrent.
+   pub async fn export(&self) -> Result<TorrentSnapshot> {
+      self.snapshot().await
    }
 
    pub async fn snapshot(&self) -> Result<TorrentSnapshot> {

--- a/crates/libtortillas/src/torrent/handle.rs
+++ b/crates/libtortillas/src/torrent/handle.rs
@@ -6,10 +6,10 @@ use tokio::sync::oneshot;
 use tracing::error;
 
 use super::{
-   PieceStorageStrategy, TorrentActor, TorrentExport, TorrentState,
+   PieceStorageStrategy, TorrentActor, TorrentExport, TorrentSnapshot, TorrentState,
    commands::{
       ExportState, GetState, ReadyHook, SetAutoStart, SetOutputPath, SetPieceManager,
-      SetPieceStorage, SetState, SetSufficientPeers,
+      SetPieceStorage, SetState, SetSufficientPeers, SnapshotState,
    },
 };
 use crate::{hashes::InfoHash, pieces::PieceManager};
@@ -95,6 +95,10 @@ impl Torrent {
 
    pub async fn export(&self) -> Result<TorrentExport> {
       Ok(*self.actor().ask(ExportState).await?)
+   }
+
+   pub async fn snapshot(&self) -> Result<TorrentSnapshot> {
+      Ok(*self.actor().ask(SnapshotState).await?)
    }
 
    pub async fn set_auto_start(&self, auto: bool) -> Result<()> {

--- a/crates/libtortillas/src/torrent/messages.rs
+++ b/crates/libtortillas/src/torrent/messages.rs
@@ -10,7 +10,7 @@ use sha1::{Digest, Sha1};
 use tracing::{info, instrument, trace, warn};
 
 use super::{
-   BLOCK_SIZE, PieceStorageStrategy, TorrentActor, TorrentExport, TorrentState,
+   BLOCK_SIZE, PieceStorageStrategy, TorrentActor, TorrentExport, TorrentSnapshot, TorrentState,
    actor::{PieceManagerProxy, ReadyHookSender},
    util,
 };
@@ -410,6 +410,11 @@ pub(crate) mod commands {
       #[message]
       pub(crate) fn export_state(&self) -> Box<TorrentExport> {
          Box::new(self.export())
+      }
+
+      #[message]
+      pub(crate) fn snapshot_state(&self) -> Box<TorrentSnapshot> {
+         Box::new(self.snapshot())
       }
    }
 }

--- a/crates/libtortillas/src/torrent/mod.rs
+++ b/crates/libtortillas/src/torrent/mod.rs
@@ -6,6 +6,7 @@ mod export;
 mod handle;
 mod messages;
 mod piece_flow;
+mod snapshot;
 mod state;
 mod storage;
 mod swarm;
@@ -15,6 +16,7 @@ pub use block::{BLOCK_SIZE, BlockMap};
 pub use export::TorrentExport;
 pub use handle::Torrent;
 pub(crate) use messages::*;
+pub use snapshot::{TorrentProgressSnapshot, TorrentSnapshot, TorrentTransferSnapshot};
 pub use state::TorrentState;
 pub use storage::PieceStorageStrategy;
 

--- a/crates/libtortillas/src/torrent/mod.rs
+++ b/crates/libtortillas/src/torrent/mod.rs
@@ -13,7 +13,7 @@ mod swarm;
 
 pub(crate) use actor::{TorrentActor, TorrentActorArgs};
 pub use block::{BLOCK_SIZE, BlockMap};
-pub use export::TorrentExport;
+pub(crate) use export::TorrentExport;
 pub use handle::Torrent;
 pub(crate) use messages::*;
 pub use snapshot::{TorrentProgressSnapshot, TorrentSnapshot, TorrentTransferSnapshot};

--- a/crates/libtortillas/src/torrent/snapshot.rs
+++ b/crates/libtortillas/src/torrent/snapshot.rs
@@ -1,0 +1,43 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use super::TorrentState;
+use crate::hashes::InfoHash;
+
+/// Stable, frontend-ready view of a torrent.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TorrentSnapshot {
+   pub info_hash: InfoHash,
+   pub name: String,
+   pub state: TorrentState,
+   pub has_metadata: bool,
+   pub is_ready: bool,
+   pub auto_start: bool,
+   pub sufficient_peers: usize,
+   pub peer_count: usize,
+   pub tracker_count: usize,
+   pub output_path: Option<PathBuf>,
+   pub progress: TorrentProgressSnapshot,
+   pub transfer: TorrentTransferSnapshot,
+}
+
+/// Display-ready torrent progress fields.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TorrentProgressSnapshot {
+   pub total_bytes: Option<usize>,
+   pub downloaded_bytes: usize,
+   pub bytes_remaining: Option<usize>,
+   pub progress_fraction: Option<f64>,
+   pub completed_pieces: usize,
+   pub partial_pieces: usize,
+   pub total_pieces: usize,
+}
+
+/// Transfer-rate fields reserved for frontend displays.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TorrentTransferSnapshot {
+   pub download_rate_bytes_per_second: Option<u64>,
+   pub upload_rate_bytes_per_second: Option<u64>,
+   pub eta_seconds: Option<u64>,
+}

--- a/crates/libtortillas/src/torrent/snapshot.rs
+++ b/crates/libtortillas/src/torrent/snapshot.rs
@@ -14,9 +14,9 @@ pub struct TorrentSnapshot {
    pub has_metadata: bool,
    pub is_ready: bool,
    pub auto_start: bool,
-   pub sufficient_peers: usize,
-   pub peer_count: usize,
-   pub tracker_count: usize,
+   pub sufficient_peers: u64,
+   pub peer_count: u64,
+   pub tracker_count: u64,
    pub output_path: Option<PathBuf>,
    pub progress: TorrentProgressSnapshot,
    pub transfer: TorrentTransferSnapshot,
@@ -25,13 +25,13 @@ pub struct TorrentSnapshot {
 /// Display-ready torrent progress fields.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TorrentProgressSnapshot {
-   pub total_bytes: Option<usize>,
-   pub downloaded_bytes: usize,
-   pub bytes_remaining: Option<usize>,
+   pub total_bytes: Option<u64>,
+   pub downloaded_bytes: u64,
+   pub bytes_remaining: Option<u64>,
    pub progress_fraction: Option<f64>,
-   pub completed_pieces: usize,
-   pub partial_pieces: usize,
-   pub total_pieces: usize,
+   pub completed_pieces: u64,
+   pub partial_pieces: u64,
+   pub total_pieces: u64,
 }
 
 /// Transfer-rate fields reserved for frontend displays.


### PR DESCRIPTION
## Summary
- add serializable torrent snapshots with display-ready progress fields
- add engine snapshots that aggregate torrent snapshots for frontend use
- make public export APIs return snapshots instead of raw internal exports

Closes #228. Part of #221.

## Tests
- cargo fmt --all --check
- cargo nextest run --workspace
- cargo clippy --workspace --all-targets -- -D warnings

Ignored network tests were not run because this change only reshapes local snapshot/export APIs and does not alter tracker or peer network behavior.