### PR TITLE
refactor: standardize peer actor ownership

### DIFF
--- a/crates/libtortillas/src/dht/messages.rs
+++ b/crates/libtortillas/src/dht/messages.rs
@@ -8,7 +8,7 @@ use tracing::{trace, warn};
 use super::{DhtActor, LookupResult, Message, NodeId, actor::DhtTorrent, announce_peer};
 use crate::{
    hashes::InfoHash,
-   peer::Peer,
+   peer::WirePeer,
    torrent::{AnnounceFrom, TorrentActor, commands::HasInfoDict, events::Announce},
 };
 
@@ -82,7 +82,7 @@ pub(crate) mod events {
          let peers = result
             .peers
             .into_iter()
-            .map(Peer::from_socket_addr)
+            .map(WirePeer::from_socket_addr)
             .collect::<Vec<_>>();
          if !peers.is_empty()
             && let Err(err) = torrent

--- a/crates/libtortillas/src/engine/messages.rs
+++ b/crates/libtortillas/src/engine/messages.rs
@@ -11,7 +11,7 @@ use crate::{
    errors::{EngineError, map_torrent_send_error},
    hashes::InfoHash,
    metainfo::MetaInfo,
-   peer::Peer,
+   peer::WirePeer,
    protocol::stream::{PeerStream, validate_handshake_protocol},
    torrent::{
       self, RestoreVerification, TorrentActor, TorrentActorArgs, TorrentSnapshot, TorrentState,
@@ -86,15 +86,17 @@ pub(crate) mod commands {
          }
 
          let info_hash = handshake.info_hash;
-         let mut peer = Peer::from_socket_addr(peer_addr);
+         let mut peer = WirePeer::from_socket_addr(peer_addr);
 
-         // Populate peer fields from parsed handshake.
          peer.id = Some(handshake.peer_id);
-         peer.reserved = handshake.reserved;
 
          if let Some(torrent) = self.torrents.get(&info_hash) {
             if let Err(err) = torrent
-               .tell(torrent::events::IncomingPeer { peer, stream })
+               .tell(torrent::events::IncomingPeer {
+                  peer,
+                  reserved: handshake.reserved,
+                  stream,
+               })
                .await
             {
                warn!(error = %err, %info_hash, "Failed to route incoming peer to torrent");

--- a/crates/libtortillas/src/lib.rs
+++ b/crates/libtortillas/src/lib.rs
@@ -248,7 +248,7 @@ pub(crate) mod testing {
    use crate::{
       hashes::{Hash, InfoHash},
       metainfo::{MagnetUri, MetaInfo, TorrentFile},
-      peer::{Peer, PeerId},
+      peer::{PeerId, WirePeer},
       protocol::{
          messages::{Handshake, PeerMessages},
          stream::PeerStream,
@@ -378,7 +378,7 @@ pub(crate) mod testing {
 
    impl LocalHttpTracker {
       /// Starts a tracker that returns the given IPv4 peers in compact form.
-      pub(crate) async fn start(peers: impl IntoIterator<Item = Peer>) -> io::Result<Self> {
+      pub(crate) async fn start(peers: impl IntoIterator<Item = WirePeer>) -> io::Result<Self> {
          let peers = Arc::new(peers.into_iter().collect::<Vec<_>>());
          let requests = Arc::new(Mutex::new(Vec::new()));
          let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await?;
@@ -408,7 +408,7 @@ pub(crate) mod testing {
    }
 
    async fn run_http_tracker(
-      listener: TcpListener, peers: Arc<Vec<Peer>>, requests: Arc<Mutex<Vec<String>>>,
+      listener: TcpListener, peers: Arc<Vec<WirePeer>>, requests: Arc<Mutex<Vec<String>>>,
    ) {
       let mut connections = JoinSet::new();
       loop {
@@ -429,7 +429,7 @@ pub(crate) mod testing {
    }
 
    async fn handle_http_tracker_connection(
-      mut stream: TcpStream, peers: Arc<Vec<Peer>>, requests: Arc<Mutex<Vec<String>>>,
+      mut stream: TcpStream, peers: Arc<Vec<WirePeer>>, requests: Arc<Mutex<Vec<String>>>,
    ) -> io::Result<()> {
       let mut buf = Vec::new();
       let mut chunk = [0; 1024];
@@ -471,7 +471,7 @@ pub(crate) mod testing {
       parts.next().map(ToOwned::to_owned)
    }
 
-   fn tracker_response_body(peers: &[Peer]) -> Vec<u8> {
+   fn tracker_response_body(peers: &[WirePeer]) -> Vec<u8> {
       let compact_peers = compact_peer_bytes(peers);
       let mut response = format!("d8:intervali1800e5:peers{}:", compact_peers.len()).into_bytes();
       response.extend_from_slice(&compact_peers);
@@ -479,7 +479,7 @@ pub(crate) mod testing {
       response
    }
 
-   fn compact_peer_bytes(peers: &[Peer]) -> Vec<u8> {
+   fn compact_peer_bytes(peers: &[WirePeer]) -> Vec<u8> {
       let mut bytes = Vec::with_capacity(peers.len() * 6);
       for peer in peers {
          let IpAddr::V4(ip) = peer.ip else {
@@ -519,8 +519,8 @@ pub(crate) mod testing {
          })
       }
 
-      pub(crate) fn peer(&self) -> Peer {
-         Peer::from_socket_addr(self.addr)
+      pub(crate) fn peer(&self) -> WirePeer {
+         WirePeer::from_socket_addr(self.addr)
       }
 
       pub(crate) async fn handshakes(&self) -> Vec<Handshake> {
@@ -601,7 +601,7 @@ pub(crate) mod testing {
 
       #[tokio::test]
       async fn local_http_tracker_returns_compact_peers_and_records_requests() {
-         let peer = Peer::from_ipv4(Ipv4Addr::LOCALHOST, 6881);
+         let peer = WirePeer::from_ipv4(Ipv4Addr::LOCALHOST, 6881);
          let tracker = LocalHttpTracker::start([peer.clone()]).await.unwrap();
          let http_tracker =
             crate::tracker::http::HttpTracker::new(tracker.uri(), test_info_hash(), None, None);
@@ -695,7 +695,7 @@ pub mod prelude {
       errors::*,
       hashes::InfoHash,
       metainfo::*,
-      peer::{Peer, PeerId},
+      peer::{PeerId, WirePeer},
       settings::*,
       torrent::*,
       tracker::Tracker,

--- a/crates/libtortillas/src/live/view.rs
+++ b/crates/libtortillas/src/live/view.rs
@@ -5,11 +5,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
    engine::EngineStatus,
    hashes::InfoHash,
-   metrics::{
-      HasTransferMetrics, PeerMetrics, TorrentMetrics, TrackerMetrics, TransferMetrics,
-      TransferSample,
-   },
-   peer::Peer,
+   metrics::{HasTransferMetrics, PeerMetrics, TorrentMetrics, TrackerMetrics, TransferMetrics},
+   peer::PeerId,
    torrent::TorrentState,
 };
 
@@ -67,24 +64,16 @@ pub struct PeerView {
 }
 
 impl PeerView {
-   pub(crate) fn from_peer(peer: &Peer, connected: bool) -> Self {
-      Self::from_peer_with_samples(peer, connected, Vec::new())
+   pub(crate) fn connected(address: SocketAddr, id: PeerId) -> Self {
+      Self::from_metrics(address, id, true, PeerMetrics::default())
    }
 
-   pub(crate) fn from_peer_with_samples(
-      peer: &Peer, connected: bool, samples: Vec<TransferSample>,
-   ) -> Self {
-      let mut metrics = peer.metrics();
-      metrics.transfer.samples = samples;
-      Self::from_peer_with_metrics(peer, connected, metrics)
-   }
-
-   pub(crate) fn from_peer_with_metrics(
-      peer: &Peer, connected: bool, metrics: PeerMetrics,
+   pub(crate) fn from_metrics(
+      address: SocketAddr, id: PeerId, connected: bool, metrics: PeerMetrics,
    ) -> Self {
       Self {
-         address: Some(peer.socket_addr()),
-         client: peer.id.map(|id| id.client_name().to_string()),
+         address: Some(address),
+         client: Some(id.client_name().to_string()),
          connected,
          metrics,
       }

--- a/crates/libtortillas/src/peer/actor.rs
+++ b/crates/libtortillas/src/peer/actor.rs
@@ -8,7 +8,7 @@ use std::{
 
 use anyhow::Context;
 use bitvec::vec::BitVec;
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
 use kameo::{
    Actor,
    actor::{ActorRef, WeakActorRef},
@@ -487,7 +487,7 @@ impl Actor for PeerActor {
          state,
          pieces,
          supports: PeerSupports::from_reserved(reserved),
-         info: PeerInfo::new(0, BytesMut::new()),
+         info: PeerInfo::default(),
          stream,
          supervisor,
          pending_block_requests: HashSet::new(),
@@ -645,7 +645,6 @@ impl Message<PeerMessages> for PeerActor {
             trace!("Peer choked us");
          }
          PeerMessages::Unchoke => {
-            self.update_last_optimistic_unchoke();
             self.set_am_choked(false);
 
             // Send all pending messages

--- a/crates/libtortillas/src/peer/actor.rs
+++ b/crates/libtortillas/src/peer/actor.rs
@@ -215,13 +215,19 @@ impl PeerActor {
 
       if self.info.have_all_bytes() {
          trace!("Peer has all info bytes, sending them to supervisor...");
-         self
+         if let Err(err) = self
             .supervisor
             .tell(torrent::events::InfoBytes {
                bytes: self.info.info_bytes(),
             })
             .await
-            .unwrap();
+         {
+            warn!(
+               error = %err,
+               peer_id = %self.id,
+               "Failed to notify torrent actor about peer info bytes"
+            );
+         }
       }
    }
 

--- a/crates/libtortillas/src/peer/actor.rs
+++ b/crates/libtortillas/src/peer/actor.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "live")]
+use std::net::SocketAddr;
 use std::{
    collections::{HashMap, HashSet, VecDeque},
    sync::{Arc, atomic::AtomicU8},
@@ -6,7 +8,7 @@ use std::{
 
 use anyhow::Context;
 use bitvec::vec::BitVec;
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use kameo::{
    Actor,
    actor::{ActorRef, WeakActorRef},
@@ -23,7 +25,7 @@ use tracing::{Span, debug, info, instrument, trace, warn};
 use crate::{
    errors::PeerActorError,
    hashes::InfoHash,
-   peer::{Peer, PeerId},
+   peer::{PeerId, PeerInfo, PeerState, PeerSupports, WirePeer},
    protocol::{stream::PeerRecv, *},
    settings::PeerSettings,
    torrent::{self, BLOCK_SIZE, TorrentActor},
@@ -62,19 +64,24 @@ struct RateSample {
 
 #[cfg(not(feature = "live"))]
 impl RateSample {
-   fn new(peer: &Peer) -> Self {
+   fn new(state: &PeerState) -> Self {
       Self {
          at: Instant::now(),
-         bytes_downloaded: peer.bytes_downloaded(),
-         bytes_uploaded: peer.bytes_uploaded(),
+         bytes_downloaded: state.bytes_downloaded(),
+         bytes_uploaded: state.bytes_uploaded(),
       }
    }
 }
 
 /// The actor that handles all communications with a given peer.
 pub(crate) struct PeerActor {
-   /// The peers state and statistics
-   peer: Peer,
+   id: PeerId,
+   #[cfg(feature = "live")]
+   address: SocketAddr,
+   pub(super) state: PeerState,
+   pub(super) pieces: Arc<BitVec<AtomicU8>>,
+   pub(super) supports: PeerSupports,
+   info: PeerInfo,
    /// The stream connecting to the peer -- either TCP or uTP
    stream: PeerStream,
    /// The [TorrentActor] that manages this peer
@@ -92,7 +99,8 @@ pub(crate) struct PeerActor {
 }
 
 pub(crate) struct PeerActorArgs {
-   pub(crate) peer: Peer,
+   pub(crate) peer: WirePeer,
+   pub(crate) reserved: [u8; 8],
    pub(crate) stream: PeerStream,
    pub(crate) supervisor: ActorRef<TorrentActor>,
    pub(crate) info_hash: InfoHash,
@@ -121,7 +129,7 @@ impl PeerActor {
       }
    }
 
-   #[instrument(skip(self, actor_ref, signal), fields(peer_addr = %self.stream, peer_id = %self.peer.id.unwrap()))]
+   #[instrument(skip(self, actor_ref, signal), fields(peer_addr = %self.stream, peer_id = %self.id))]
    fn check_message_signal(
       &mut self, actor_ref: WeakActorRef<Self>, signal: Result<PeerMessages, PeerActorError>,
    ) -> Option<Signal<Self>> {
@@ -156,7 +164,7 @@ impl PeerActor {
    /// 0010](https://www.bittorrent.org/beps/bep_0010.html), and the 3 extension messages as specified
    /// in [BEP 0009](https://www.bittorrent.org/beps/bep_0009.html), with the exception of
    /// `Reject`.
-   #[instrument(skip(self, _extended_id, extended_message, metadata), fields(peer_addr = %self.stream, peer_id = %self.peer.id.unwrap()))]
+   #[instrument(skip(self, _extended_id, extended_message, metadata), fields(peer_addr = %self.stream, peer_id = %self.id))]
    async fn handle_extended_message(
       &mut self, _extended_id: u8, extended_message: Option<ExtendedMessage>,
       metadata: &Option<Bytes>,
@@ -166,11 +174,11 @@ impl PeerActor {
          if extended_message.is_bep_0009_data().unwrap_or_default()
             && let Some(metadata) = metadata
          {
-            if let Err(e) = self.peer.info.append_to_bytes(metadata) {
+            if let Err(e) = self.info.append_to_bytes(metadata) {
                trace!(error = %e, "Failed to append metadata bytes");
             } else {
                // Request next piece if we don't have all the piece bytes
-               if !self.peer.info.have_all_bytes() {
+               if !self.info.have_all_bytes() {
                   let next_piece = extended_message.piece.expect("Should always be Some") + 1;
 
                   self
@@ -181,7 +189,7 @@ impl PeerActor {
          }
 
          if let Ok(id) = extended_message.supports_bep_0009() {
-            self.peer.set_bep_0009(id);
+            self.set_bep_0009(id);
 
             // If peer has metadata and we don't already have it, request metadata from peer
             if let Some(metadata_size) = extended_message.metadata_size {
@@ -205,12 +213,12 @@ impl PeerActor {
          }
       }
 
-      if self.peer.info.have_all_bytes() {
+      if self.info.have_all_bytes() {
          trace!("Peer has all info bytes, sending them to supervisor...");
          self
             .supervisor
             .tell(torrent::events::InfoBytes {
-               bytes: self.peer.info.info_bytes(),
+               bytes: self.info.info_bytes(),
             })
             .await
             .unwrap();
@@ -218,29 +226,26 @@ impl PeerActor {
    }
 
    /// Contains the logic for requesting a piece from a peer under [BEP 0009](https://www.bittorrent.org/beps/bep_0009.html)/[BEP 0010](https://www.bittorrent.org/beps/bep_0010.html). This function expects the exact piece to be specified -- in other words, when requesting the next piece of metadata, this function will not automatically increment the `piece` field. The caller of the function is expected to handle this.
-   #[instrument(skip(self), fields(peer_addr = %self.stream, peer_id = %self.peer.id.unwrap()))]
+   #[instrument(skip(self), fields(peer_addr = %self.stream, peer_id = %self.id))]
    async fn request_metadata(&mut self, metadata_size: Option<usize>, piece: usize) {
       if let Some(size) = metadata_size {
-         self.peer.info.set_info_size(size);
+         self.info.set_info_size(size);
       }
 
-      if self.peer.info.info_size() > 0 && !self.peer.info.have_all_bytes() {
+      if self.info.info_size() > 0 && !self.info.have_all_bytes() {
          let mut extended_message = ExtendedMessage::new();
          extended_message.piece = Some(piece);
          extended_message.msg_type = Some(ExtendedMessageType::Request);
 
-         let message = PeerMessages::Extended(
-            self.peer.bep_0009_id(),
-            Box::new(Some(extended_message)),
-            None,
-         );
+         let message =
+            PeerMessages::Extended(self.bep_0009_id(), Box::new(Some(extended_message)), None);
 
          if let Err(e) = self.send_message(message).await {
             trace!(error = %e, piece, "Failed to send metadata request");
          }
       } else {
          trace!(
-            info_size = self.peer.info.info_size(),
+            info_size = self.info.info_size(),
             "Peer already has all metadata bytes or info size is invalid"
          );
       }
@@ -248,9 +253,9 @@ impl PeerActor {
 
    /// Checks if the peer has any bits in the bitfield that we don't have, and
    /// sends an interested message if so.
-   #[instrument(skip(self), fields(peer_addr = %self.stream, peer_id = %self.peer.id.unwrap()))]
+   #[instrument(skip(self), fields(peer_addr = %self.stream, peer_id = %self.id))]
    async fn determine_interest(&mut self) {
-      let their_bitfield = self.peer.pieces.clone();
+      let their_bitfield = self.pieces.clone();
       let response = match self
          .supervisor
          .ask(torrent::commands::InterestingPieces {
@@ -288,13 +293,13 @@ impl PeerActor {
          debug!("Peer has no pieces we need - not interested");
       }
 
-      self.peer.set_am_interested(has_interesting_pieces);
+      self.set_am_interested(has_interesting_pieces);
    }
 
    /// Sends all queued messages to the peer. This sends synchronously, and will
    /// not return until each message has been sent. This is because most of
    /// the time we want the messages to be sent in their original order.
-   #[instrument(skip(self), fields(peer_addr = %self.stream, peer_id = %self.peer.id.unwrap()))]
+   #[instrument(skip(self), fields(peer_addr = %self.stream, peer_id = %self.id))]
    async fn flush_queue(&mut self) {
       if self.pending_message_requests.is_empty() {
          return;
@@ -314,7 +319,7 @@ impl PeerActor {
    }
 
    /// Flushes/resends all pending block requests to the peer.
-   #[instrument(skip(self), fields(peer_addr = %self.stream, peer_id = %self.peer.id.unwrap()))]
+   #[instrument(skip(self), fields(peer_addr = %self.stream, peer_id = %self.id))]
    async fn flush_block_requests(&mut self) {
       if self.pending_block_requests.is_empty() {
          return;
@@ -353,9 +358,9 @@ impl PeerActor {
    /// Unless you're doing something like a `KeepAlive` message or a piece
    /// request, you should use this function over sending on the stream
    /// directly.
-   #[instrument(skip(self), fields(peer_addr = %self.stream, peer_id = %self.peer.id.unwrap()))]
+   #[instrument(skip(self), fields(peer_addr = %self.stream, peer_id = %self.id))]
    async fn send_message(&mut self, msg: PeerMessages) -> Result<(), PeerActorError> {
-      if self.peer.am_choked() && matches!(msg, PeerMessages::Request(..)) {
+      if self.am_choked() && matches!(msg, PeerMessages::Request(..)) {
          return Ok(());
       }
 
@@ -366,22 +371,21 @@ impl PeerActor {
 #[cfg(feature = "live")]
 impl PeerActor {
    fn snapshot_stats(&mut self) -> Option<PeerStats> {
-      let id = self.peer.id?;
+      let id = self.id;
       let now = Instant::now();
-      let totals = self.peer.traffic_totals();
+      let totals = self.traffic_totals();
       let sample = TimedTransferSample::new(now, totals);
       let transfer_sample = sample.sample_since(self.last_rate_sample);
       self.last_rate_sample = sample;
       let transfer = TransferMetrics::from_sample(transfer_sample);
-      let mut metrics = self.peer.metrics();
+      let mut metrics = self.metrics();
       metrics.transfer = transfer;
-      self
-         .live_handle
-         .publish_metrics(PeerView::from_peer_with_metrics(
-            &self.peer,
-            true,
-            metrics.clone(),
-         ));
+      self.live_handle.publish_metrics(PeerView::from_metrics(
+         self.address,
+         self.id,
+         true,
+         metrics.clone(),
+      ));
 
       let rates = metrics.transfer.rates().unwrap_or_default();
       Some(PeerStats {
@@ -398,10 +402,10 @@ impl PeerActor {
 #[cfg(not(feature = "live"))]
 impl PeerActor {
    fn snapshot_stats(&mut self) -> Option<PeerStats> {
-      let id = self.peer.id?;
+      let id = self.id;
       let now = Instant::now();
-      let bytes_downloaded = self.peer.bytes_downloaded();
-      let bytes_uploaded = self.peer.bytes_uploaded();
+      let bytes_downloaded = self.bytes_downloaded();
+      let bytes_uploaded = self.bytes_uploaded();
       let elapsed_secs = now
          .duration_since(self.last_rate_sample.at)
          .as_secs()
@@ -418,8 +422,8 @@ impl PeerActor {
 
       Some(PeerStats {
          id,
-         interested: self.peer.interested(),
-         client_choking: self.peer.choked(),
+         interested: self.interested(),
+         client_choking: self.choked(),
          download_rate: u64::try_from(download_rate).unwrap_or(u64::MAX),
          upload_rate: u64::try_from(upload_rate).unwrap_or(u64::MAX),
       })
@@ -434,7 +438,8 @@ impl Actor for PeerActor {
    /// messages have been sent or received from the peer.
    async fn on_start(args: Self::Args, _: ActorRef<Self>) -> Result<Self, Self::Error> {
       let PeerActorArgs {
-         mut peer,
+         peer,
+         reserved,
          mut stream,
          supervisor,
          info_hash,
@@ -442,9 +447,13 @@ impl Actor for PeerActor {
          #[cfg(feature = "live")]
          live_handle,
       } = args;
-      peer.share_traffic_with(&stream.peer_state());
+      let id = peer.id.expect("connected peer should have an id");
+      #[cfg(feature = "live")]
+      let address = peer.socket_addr();
+      let state = stream.peer_state();
+      let pieces = Arc::new(BitVec::EMPTY);
 
-      info!(peer_id = %peer.id.unwrap(),  peer_addr = %stream, torrent_id = %info_hash, "Peer connected");
+      info!(peer_id = %id, peer_addr = %stream, torrent_id = %info_hash, "Peer connected");
       let bitfield = match supervisor.ask(torrent::commands::GetBitfield).await {
          Ok(bitfield) => bitfield,
          Err(err) => {
@@ -461,18 +470,24 @@ impl Actor for PeerActor {
 
       supervisor
          .tell(torrent::events::PeerReady {
-            id: peer.id.unwrap(),
-            available_pieces: peer.pieces.clone(),
+            id,
+            available_pieces: pieces.clone(),
          })
          .await
          .map_err(|e| PeerActorError::SupervisorCommunicationFailed(e.to_string()))?;
 
       Ok(Self {
+         id,
          #[cfg(feature = "live")]
-         last_rate_sample: TimedTransferSample::new(Instant::now(), peer.traffic_totals()),
+         address,
+         #[cfg(feature = "live")]
+         last_rate_sample: TimedTransferSample::new(Instant::now(), state.traffic_totals()),
          #[cfg(not(feature = "live"))]
-         last_rate_sample: RateSample::new(&peer),
-         peer,
+         last_rate_sample: RateSample::new(&state),
+         state,
+         pieces,
+         supports: PeerSupports::from_reserved(reserved),
+         info: PeerInfo::new(0, BytesMut::new()),
          stream,
          supervisor,
          pending_block_requests: HashSet::new(),
@@ -486,15 +501,15 @@ impl Actor for PeerActor {
    async fn on_stop(
       &mut self, _: WeakActorRef<Self>, _: ActorStopReason,
    ) -> Result<(), Self::Error> {
-      if let Some(peer_id) = self.peer.id
-         && let Err(err) = self
-            .supervisor
-            .tell(torrent::commands::KillPeer {
-               id: peer_id,
-               #[cfg(feature = "live")]
-               handle: self.live_handle.clone(),
-            })
-            .await
+      let peer_id = self.id;
+      if let Err(err) = self
+         .supervisor
+         .tell(torrent::commands::KillPeer {
+            id: peer_id,
+            #[cfg(feature = "live")]
+            handle: self.live_handle.clone(),
+         })
+         .await
       {
          warn!(error = %err, %peer_id, "Failed to notify torrent actor about stopped peer");
       }
@@ -503,21 +518,18 @@ impl Actor for PeerActor {
    }
 
    /// Coerces messages from the [PeerStream] to a [Message]
-   #[instrument(skip(self, actor_ref, mailbox_rx), fields(peer_addr = %self.stream, peer_id = %self.peer.id.unwrap()))]
+   #[instrument(skip(self, actor_ref, mailbox_rx), fields(peer_addr = %self.stream, peer_id = %self.id))]
    async fn next(
       &mut self, actor_ref: WeakActorRef<Self>, mailbox_rx: &mut MailboxReceiver<Self>,
    ) -> Result<Option<Signal<Self>>, Self::Error> {
       loop {
          // Send a BEP 3 keepalive after an idle period, then disconnect only if
          // the peer remains silent until the disconnect deadline.
-         let last_received = self
-            .peer
-            .last_message_received()
-            .unwrap_or_else(Instant::now);
+         let last_received = self.last_message_received().unwrap_or_else(Instant::now);
          let idle = last_received.elapsed();
 
          if idle >= self.settings.disconnect_timeout {
-            let id = self.peer.id.expect("Peer ID should exist");
+            let id = self.id;
             if let Err(err) = self
                .supervisor
                .tell(torrent::commands::KillPeer {
@@ -535,7 +547,6 @@ impl Actor for PeerActor {
          }
 
          let keepalive_sent = self
-            .peer
             .last_message_sent()
             .is_some_and(|last_sent| last_sent >= last_received);
          if idle >= self.settings.keepalive_timeout && !keepalive_sent {
@@ -548,7 +559,7 @@ impl Actor for PeerActor {
                warn!(error = %err, "Failed to send keep alive message to peer");
                return Ok(Some(Signal::Stop));
             }
-            self.peer.update_last_message_sent();
+            self.update_last_message_sent();
          }
 
          let next_idle_deadline = if keepalive_sent || idle >= self.settings.keepalive_timeout {
@@ -579,11 +590,11 @@ impl Actor for PeerActor {
 impl Message<PeerMessages> for PeerActor {
    type Reply = ();
 
-   #[instrument(skip(self, msg), fields(peer_addr = %self.stream, peer_id = %self.peer.id.unwrap(), message = %msg))]
+   #[instrument(skip(self, msg), fields(peer_addr = %self.stream, peer_id = %self.id, message = %msg))]
    async fn handle(
       &mut self, msg: PeerMessages, _: &mut KameoContext<Self, Self::Reply>,
    ) -> Self::Reply {
-      self.peer.update_last_message_received();
+      self.update_last_message_received();
       #[cfg(feature = "live")]
       let publish_live_state = matches!(
          &msg,
@@ -606,10 +617,7 @@ impl Message<PeerMessages> for PeerActor {
             // Only send the piece to the supervisor if they request it or it hasn't been
             // cancelled
             if self.pending_block_requests.remove(&key) {
-               let Some(peer_id) = self.peer.id else {
-                  warn!("Received piece from peer without id; ignoring");
-                  return;
-               };
+               let peer_id = self.id;
                let supervisor_msg = torrent::events::IncomingPiece {
                   peer_id,
                   index: index as usize,
@@ -633,12 +641,12 @@ impl Message<PeerMessages> for PeerActor {
             }
          }
          PeerMessages::Choke => {
-            self.peer.set_am_choked(true);
+            self.set_am_choked(true);
             trace!("Peer choked us");
          }
          PeerMessages::Unchoke => {
-            self.peer.update_last_optimistic_unchoke();
-            self.peer.set_am_choked(false);
+            self.update_last_optimistic_unchoke();
+            self.set_am_choked(false);
 
             // Send all pending messages
             self.flush_queue().await;
@@ -647,11 +655,11 @@ impl Message<PeerMessages> for PeerActor {
             trace!("Peer unchoked us");
          }
          PeerMessages::Interested => {
-            self.peer.set_interested(true);
+            self.set_interested(true);
             trace!("Peer is interested in our pieces");
          }
          PeerMessages::NotInterested => {
-            self.peer.set_interested(false);
+            self.set_interested(false);
             trace!("Peer is not interested in our pieces");
          }
          PeerMessages::KeepAlive => {
@@ -660,9 +668,9 @@ impl Message<PeerMessages> for PeerActor {
          PeerMessages::Have(piece_index) => {
             trace!(piece_index, "Peer has a new piece");
             let idx = piece_index as usize;
-            if idx < self.peer.pieces.len() {
-               let was_set = self.peer.pieces[idx];
-               self.peer.pieces.set_aliased(idx, true);
+            if idx < self.pieces.len() {
+               let was_set = self.pieces[idx];
+               self.pieces.set_aliased(idx, true);
                // If this is a new piece, our interest may change.
                if !was_set {
                   self.determine_interest().await;
@@ -670,13 +678,13 @@ impl Message<PeerMessages> for PeerActor {
             } else {
                warn!(
                   piece_index,
-                  len = self.peer.pieces.len(),
+                  len = self.pieces.len(),
                   "Have index out of bounds; ignoring"
                );
             }
          }
          PeerMessages::Request(index, offset, length) => {
-            if self.peer.choked() {
+            if self.choked() {
                trace!(
                   piece_index = index,
                   offset, length, "Ignoring request from choked peer"
@@ -744,7 +752,7 @@ impl Message<PeerMessages> for PeerActor {
                .remove(&(index as usize, offset as usize, length as usize));
          }
          PeerMessages::Bitfield(bitfield) => {
-            self.peer.pieces = bitfield;
+            self.pieces = bitfield;
             self.determine_interest().await;
             self.notify_ready().await;
          }
@@ -754,25 +762,27 @@ impl Message<PeerMessages> for PeerActor {
       }
       #[cfg(feature = "live")]
       if publish_live_state {
-         let samples = self.live_handle.view().metrics.transfer.samples;
-         self
-            .live_handle
-            .publish_state(PeerView::from_peer_with_samples(&self.peer, true, samples));
+         let mut metrics = self.metrics();
+         metrics.transfer.samples = self.live_handle.view().metrics.transfer.samples;
+         self.live_handle.publish_state(PeerView::from_metrics(
+            self.address,
+            self.id,
+            true,
+            metrics,
+         ));
       }
    }
 }
 
 impl PeerActor {
    async fn notify_ready(&self) {
-      let Some(peer_id) = self.peer.id else {
-         return;
-      };
+      let peer_id = self.id;
 
       if let Err(err) = self
          .supervisor
          .tell(torrent::events::PeerReady {
             id: peer_id,
-            available_pieces: self.peer.pieces.clone(),
+            available_pieces: self.pieces.clone(),
          })
          .await
       {
@@ -781,9 +791,7 @@ impl PeerActor {
    }
 
    async fn reject_piece_request(&self, index: usize, begin: usize) {
-      let Some(peer_id) = self.peer.id else {
-         return;
-      };
+      let peer_id = self.id;
       if let Err(err) = self
          .supervisor
          .tell(torrent::events::PeerRejectedRequest {
@@ -809,9 +817,9 @@ pub(crate) mod commands {
    #[messages]
    impl PeerActor {
       #[message(derive(Clone, Debug))]
-      #[instrument(skip(self), fields(peer_addr = %self.stream, peer_id = %self.peer.id.unwrap()))]
+      #[instrument(skip(self), fields(peer_addr = %self.stream, peer_id = %self.id))]
       pub(crate) async fn need_piece(&mut self, index: usize, begin: usize, length: usize) {
-         let piece_exists = matches!(self.peer.pieces.get(index).as_deref(), Some(true));
+         let piece_exists = matches!(self.pieces.get(index).as_deref(), Some(true));
 
          if !piece_exists {
             trace!(
@@ -822,7 +830,7 @@ pub(crate) mod commands {
             return;
          }
 
-         if self.peer.am_choked() {
+         if self.am_choked() {
             trace!(piece_index = index, "Peer is choking us, queueing request");
             self.pending_block_requests.insert((index, begin, length));
             return;
@@ -852,7 +860,7 @@ pub(crate) mod commands {
       }
 
       #[message(derive(Clone, Debug))]
-      #[instrument(skip(self), fields(peer_addr = %self.stream, peer_id = %self.peer.id.unwrap()))]
+      #[instrument(skip(self), fields(peer_addr = %self.stream, peer_id = %self.id))]
       pub(crate) async fn cancel_piece(&mut self, index: usize, begin: usize, length: usize) {
          if !self
             .pending_block_requests
@@ -883,9 +891,9 @@ pub(crate) mod commands {
       }
 
       #[message(derive(Clone, Debug))]
-      #[instrument(skip(self), fields(peer_addr = %self.stream, peer_id = %self.peer.id.unwrap()))]
+      #[instrument(skip(self), fields(peer_addr = %self.stream, peer_id = %self.id))]
       pub(crate) async fn set_choked(&mut self, choked: bool) {
-         if self.peer.choked() == choked {
+         if self.choked() == choked {
             return;
          }
 
@@ -900,7 +908,7 @@ pub(crate) mod commands {
             return;
          }
 
-         self.peer.set_choked(choked);
+         self.set_client_choking(choked);
          trace!(choked, "Updated peer choke state");
       }
 

--- a/crates/libtortillas/src/peer/info.rs
+++ b/crates/libtortillas/src/peer/info.rs
@@ -1,66 +1,19 @@
 use anyhow::ensure;
 use bytes::{Bytes, BytesMut};
 
-use crate::{hashes::InfoHash, metainfo::Info};
-
 /// Metadata assembly state owned by a connected peer actor.
 ///
 /// If you're unfamiliar, you can get metadata from a peer using the protocol
 /// described in [BEP 0009](https://www.bittorrent.org/beps/bep_0009.html) and [BEP 0010](https://www.bittorrent.org/beps/bep_0010.html)
+#[derive(Default)]
 pub(crate) struct PeerInfo {
    info_size: usize,
    info_bytes: BytesMut,
 }
 
-#[allow(dead_code)]
 impl PeerInfo {
-   pub(crate) fn new(info_size: usize, info_bytes: BytesMut) -> Self {
-      PeerInfo {
-         info_size,
-         info_bytes,
-      }
-   }
-
    pub(crate) fn set_info_size(&mut self, info_size: usize) {
       self.info_size = info_size;
-   }
-
-   pub(crate) fn set_info_bytes(&mut self, info_bytes: BytesMut) {
-      self.info_bytes = info_bytes;
-   }
-
-   /// Generates an Info dict from the current bytes in info_bytes. If the hash
-   /// of the created Info dict is not the same as the inputted info hash, an
-   /// error will be returned. If the hash is the same, the newly created
-   /// Info will be returned.
-   pub(crate) async fn generate_info_from_bytes(
-      &self, info_hash: InfoHash,
-   ) -> anyhow::Result<Info> {
-      // We have to do this because sometimes info dicts have non-standard properties
-      // that get discared by serde automatically, causing the hash to be
-      // different.
-      //
-      // The solution? Hash the raw bytes of it instead of parsing it first.
-      let real_info_hash: InfoHash = {
-         use sha1::{Digest, Sha1};
-         let mut hasher = Sha1::new();
-
-         hasher.update(&self.info_bytes);
-         let hash = hasher.finalize();
-         hash.to_vec().try_into()?
-      };
-
-      // Put bytes into Info struct
-      // The metadata should be bencoded bytes.
-      let info_dict: Info = serde_bencode::from_bytes(self.info_bytes.as_ref())?;
-
-      // Validate hash of struct with given info hash
-      ensure!(
-         real_info_hash == info_hash,
-         "Inputted info_hash was not the same as generated info_hash"
-      );
-
-      Ok(info_dict)
    }
 
    /// A helper function for handling any issues with appending the new bytes to
@@ -100,11 +53,5 @@ impl PeerInfo {
 
    pub(crate) fn info_bytes(&self) -> Bytes {
       self.info_bytes.clone().freeze()
-   }
-
-   /// Resets the PeerInfo struct.
-   pub(crate) fn reset(&mut self) {
-      self.info_bytes = BytesMut::new();
-      self.info_size = 0;
    }
 }

--- a/crates/libtortillas/src/peer/info.rs
+++ b/crates/libtortillas/src/peer/info.rs
@@ -3,20 +3,18 @@ use bytes::{Bytes, BytesMut};
 
 use crate::{hashes::InfoHash, metainfo::Info};
 
-/// A helper struct for Peer. Manages and handles any metadata (informally
-/// called an Info dict, as is the case here) from a Peer.
+/// Metadata assembly state owned by a connected peer actor.
 ///
 /// If you're unfamiliar, you can get metadata from a peer using the protocol
 /// described in [BEP 0009](https://www.bittorrent.org/beps/bep_0009.html) and [BEP 0010](https://www.bittorrent.org/beps/bep_0010.html)
-#[derive(Clone)]
-pub struct PeerInfo {
+pub(crate) struct PeerInfo {
    info_size: usize,
    info_bytes: BytesMut,
 }
 
 #[allow(dead_code)]
 impl PeerInfo {
-   pub fn new(info_size: usize, info_bytes: BytesMut) -> Self {
+   pub(crate) fn new(info_size: usize, info_bytes: BytesMut) -> Self {
       PeerInfo {
          info_size,
          info_bytes,

--- a/crates/libtortillas/src/peer/mod.rs
+++ b/crates/libtortillas/src/peer/mod.rs
@@ -8,16 +8,13 @@ use std::{
    fmt::{self, Debug, Display},
    hash::{Hash as InternalHash, Hasher},
    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
-   sync::{Arc, atomic::AtomicU8},
 };
 
 pub(crate) use actor::*;
-use bitvec::vec::BitVec;
-use bytes::BytesMut;
 pub use id::*;
-pub use info::*;
-pub use state::*;
-pub use supports::*;
+pub(crate) use info::*;
+pub(crate) use state::*;
+pub(crate) use supports::*;
 
 /// It should be noted that the *name* PeerKey is slightly deprecated from
 /// previous renditions of libtortillas. The idea of having a type for the "key"
@@ -26,67 +23,53 @@ pub type PeerKey = SocketAddr;
 
 pub const MAGIC_STRING: &[u8] = b"BitTorrent protocol";
 
-/// Represents a BitTorrent peer with connection state and statistics.
-/// Traffic totals and rates use bytes and bytes per second respectively.
+/// The identity advertised for a peer on the BitTorrent wire.
+///
+/// Connection state belongs to the peer actor once a connection is
+/// established.
 #[derive(Clone)]
-pub struct Peer {
+pub struct WirePeer {
    pub ip: IpAddr,
    pub port: u16,
-   pub state: PeerState,
-   pub pieces: Arc<BitVec<AtomicU8>>,
-   /// The reserved bytes that the peer sent us in their handshake. This
-   /// indicates what extensions the peer supports.
-   pub reserved: [u8; 8],
-   pub peer_supports: PeerSupports,
    pub id: Option<PeerId>,
-   pub info: PeerInfo,
 }
 
-impl Debug for Peer {
+impl Debug for WirePeer {
    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-      f.debug_struct("Peer")
+      f.debug_struct("WirePeer")
          .field("addr", &self.socket_addr())
-         .field("choked", &self.choked())
-         .field("interested", &self.interested())
-         .field("am_choked", &self.am_choked())
-         .field("am_interested", &self.am_interested())
          .field("id", &self.id)
          .finish()
    }
 }
 
-impl InternalHash for Peer {
+impl InternalHash for WirePeer {
    fn hash<H: Hasher>(&self, state: &mut H) {
       self.socket_addr().hash(state)
    }
 }
 
-impl Eq for Peer {}
-impl PartialEq for Peer {
+impl Eq for WirePeer {}
+impl PartialEq for WirePeer {
    fn eq(&self, other: &Self) -> bool {
       self.socket_addr() == other.socket_addr()
    }
 }
 
-impl Display for Peer {
+impl Display for WirePeer {
    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-      write!(f, "{}:{}", self.ip, self.port)
+      let display = match &self.id {
+         Some(id) => id.to_string(),
+         None => format!("{}:{}", self.ip, self.port),
+      };
+      write!(f, "{}", display)
    }
 }
 
-impl Peer {
+impl WirePeer {
    /// Create a new peer with the given IP address and port
    pub fn new(ip: IpAddr, port: u16) -> Self {
-      Peer {
-         ip,
-         port,
-         state: PeerState::new(),
-         pieces: Arc::new(BitVec::EMPTY),
-         reserved: [0u8; 8],
-         peer_supports: PeerSupports::new(),
-         id: None,
-         info: PeerInfo::new(0, BytesMut::new()),
-      }
+      Self { ip, port, id: None }
    }
 
    /// Create a new peer from an IPv4 address and port

--- a/crates/libtortillas/src/peer/state.rs
+++ b/crates/libtortillas/src/peer/state.rs
@@ -8,17 +8,19 @@ use std::{
 
 use atomic_time::AtomicOptionInstant;
 
-use super::Peer;
+use super::PeerActor;
 #[cfg(feature = "live")]
 use crate::metrics::{ByteCount, PeerMetrics, TrafficTotals, TransferMetrics};
 
-/// A helper struct for Peer that maintains a given peers state. This state
-/// includes both the state defined in [BEP 0003](https://www.bittorrent.org/beps/bep_0003.html) and our own state which we
-/// wish to maintain (ex. total bytes downloaded).
+/// Runtime state for a connected peer.
+///
+/// This includes both the state defined in
+/// [BEP 0003](https://www.bittorrent.org/beps/bep_0003.html) and local
+/// accounting such as total bytes downloaded.
 ///
 /// The general intent of this struct is to make it easier for us to "throw"
 /// state across threads -- every field in here is an atomic Arc, which means
-/// that it's very easy to do something like this (in an impl of the Peer
+/// that it's very easy to do something like this (in an impl of the PeerActor
 /// struct):
 ///
 /// ```ignore
@@ -30,7 +32,7 @@ use crate::metrics::{ByteCount, PeerMetrics, TrafficTotals, TransferMetrics};
 /// `clone()` operations on this struct should be relatively lightweight, seeing
 /// that everything is contained in an Arc.
 #[derive(Clone)]
-pub struct PeerState {
+pub(crate) struct PeerState {
    /// Whether we are choking the remote peer
    am_choking: Arc<AtomicBool>,
    /// Whether the remote peer is interested in us
@@ -60,8 +62,8 @@ impl Default for PeerState {
 }
 
 impl PeerState {
-   pub fn new() -> Self {
-      PeerState {
+   pub(crate) fn new() -> Self {
+      Self {
          am_choking: Arc::new(true.into()),
          peer_interested: Arc::new(false.into()),
          peer_choking: Arc::new(true.into()),
@@ -86,6 +88,14 @@ impl PeerState {
       self.bytes_downloaded = state.bytes_downloaded.clone();
       self.bytes_uploaded = state.bytes_uploaded.clone();
    }
+
+   pub(crate) fn bytes_downloaded(&self) -> usize {
+      self.bytes_downloaded.load(Ordering::Relaxed)
+   }
+
+   pub(crate) fn bytes_uploaded(&self) -> usize {
+      self.bytes_uploaded.load(Ordering::Relaxed)
+   }
 }
 
 #[cfg(feature = "live")]
@@ -104,8 +114,8 @@ impl PeerState {
 
 /// A bunch of helper methods (basically getter and setter wrappers)
 #[allow(dead_code)]
-impl Peer {
-   pub(crate) fn set_choked(&self, is_choked: bool) {
+impl PeerActor {
+   pub(crate) fn set_client_choking(&self, is_choked: bool) {
       self.state.am_choking.store(is_choked, Ordering::Release);
    }
 
@@ -172,25 +182,25 @@ impl Peer {
       self.state.last_optimistic_unchoke.load(Ordering::Acquire)
    }
 
-   pub fn last_message_sent(&self) -> Option<Instant> {
+   pub(crate) fn last_message_sent(&self) -> Option<Instant> {
       self.state.last_message_sent.load(Ordering::Acquire)
    }
 
-   pub fn last_message_received(&self) -> Option<Instant> {
+   pub(crate) fn last_message_received(&self) -> Option<Instant> {
       self.state.last_message_received.load(Ordering::Acquire)
    }
 
-   pub fn bytes_downloaded(&self) -> usize {
-      self.state.bytes_downloaded.load(Ordering::Relaxed)
+   pub(crate) fn bytes_downloaded(&self) -> usize {
+      self.state.bytes_downloaded()
    }
 
-   pub fn bytes_uploaded(&self) -> usize {
-      self.state.bytes_uploaded.load(Ordering::Relaxed)
+   pub(crate) fn bytes_uploaded(&self) -> usize {
+      self.state.bytes_uploaded()
    }
 }
 
 #[cfg(feature = "live")]
-impl Peer {
+impl PeerActor {
    pub(crate) fn traffic_totals(&self) -> TrafficTotals {
       self.state.traffic_totals()
    }

--- a/crates/libtortillas/src/peer/state.rs
+++ b/crates/libtortillas/src/peer/state.rs
@@ -36,13 +36,11 @@ pub(crate) struct PeerState {
    /// Whether we are choking the remote peer
    am_choking: Arc<AtomicBool>,
    /// Whether the remote peer is interested in us
-   pub(crate) peer_interested: Arc<AtomicBool>,
+   peer_interested: Arc<AtomicBool>,
    /// Whether the remote peer is choking us
-   pub(crate) peer_choking: Arc<AtomicBool>,
+   peer_choking: Arc<AtomicBool>,
    /// Our interest status
    am_interested: Arc<AtomicBool>,
-   /// The timestamp of the last time that a peer unchoked us
-   last_optimistic_unchoke: Arc<AtomicOptionInstant>,
    /// Defaults to None. Does not update on initial handshake, initial sending
    /// of bitfield, or initial sending of Interested message.
    last_message_sent: Arc<AtomicOptionInstant>,
@@ -68,7 +66,6 @@ impl PeerState {
          peer_interested: Arc::new(false.into()),
          peer_choking: Arc::new(true.into()),
          am_interested: Arc::new(false.into()),
-         last_optimistic_unchoke: Arc::new(AtomicOptionInstant::none()),
          last_message_received: Arc::new(AtomicOptionInstant::none()),
          last_message_sent: Arc::new(AtomicOptionInstant::none()),
          bytes_downloaded: Arc::new(0.into()),
@@ -84,15 +81,12 @@ impl PeerState {
       self.bytes_uploaded.fetch_add(bytes, Ordering::Relaxed);
    }
 
-   pub(crate) fn share_traffic_with(&mut self, state: &Self) {
-      self.bytes_downloaded = state.bytes_downloaded.clone();
-      self.bytes_uploaded = state.bytes_uploaded.clone();
-   }
-
+   #[cfg(not(feature = "live"))]
    pub(crate) fn bytes_downloaded(&self) -> usize {
       self.bytes_downloaded.load(Ordering::Relaxed)
    }
 
+   #[cfg(not(feature = "live"))]
    pub(crate) fn bytes_uploaded(&self) -> usize {
       self.bytes_uploaded.load(Ordering::Relaxed)
    }
@@ -112,8 +106,6 @@ impl PeerState {
    }
 }
 
-/// A bunch of helper methods (basically getter and setter wrappers)
-#[allow(dead_code)]
 impl PeerActor {
    pub(crate) fn set_client_choking(&self, is_choked: bool) {
       self.state.am_choking.store(is_choked, Ordering::Release);
@@ -137,13 +129,6 @@ impl PeerActor {
          .store(is_interested, Ordering::Release);
    }
 
-   pub(crate) fn update_last_optimistic_unchoke(&self) {
-      self
-         .state
-         .last_optimistic_unchoke
-         .store(Some(Instant::now()), Ordering::Release);
-   }
-
    pub(crate) fn update_last_message_sent(&self) {
       self
          .state
@@ -158,10 +143,6 @@ impl PeerActor {
          .store(Some(Instant::now()), Ordering::Release);
    }
 
-   pub(crate) fn share_traffic_with(&mut self, state: &PeerState) {
-      self.state.share_traffic_with(state);
-   }
-
    pub(crate) fn choked(&self) -> bool {
       self.state.am_choking.load(Ordering::Acquire)
    }
@@ -174,12 +155,9 @@ impl PeerActor {
       self.state.peer_choking.load(Ordering::Acquire)
    }
 
+   #[cfg(feature = "live")]
    pub(crate) fn am_interested(&self) -> bool {
       self.state.am_interested.load(Ordering::Acquire)
-   }
-
-   pub(crate) fn last_optimistic_unchoke(&self) -> Option<Instant> {
-      self.state.last_optimistic_unchoke.load(Ordering::Acquire)
    }
 
    pub(crate) fn last_message_sent(&self) -> Option<Instant> {
@@ -190,10 +168,12 @@ impl PeerActor {
       self.state.last_message_received.load(Ordering::Acquire)
    }
 
+   #[cfg(not(feature = "live"))]
    pub(crate) fn bytes_downloaded(&self) -> usize {
       self.state.bytes_downloaded()
    }
 
+   #[cfg(not(feature = "live"))]
    pub(crate) fn bytes_uploaded(&self) -> usize {
       self.state.bytes_uploaded()
    }

--- a/crates/libtortillas/src/peer/supports.rs
+++ b/crates/libtortillas/src/peer/supports.rs
@@ -1,62 +1,43 @@
-use std::sync::{
-   Arc,
-   atomic::{AtomicBool, AtomicU8, Ordering},
-};
-
-use super::Peer;
-
 /// A helper struct to determine what BEPs a given peer supports.
 ///
 /// BEP support that is derived from the m dictionary in [BEP 0010](https://www.bittorrent.org/beps/bep_0010.html) is denoted by a u8, and
 /// BEP support that is derived from the handshake is denoted by a boolean.
 ///
-/// When initalized with new, every field is initialized as unsupported: a 0 for
-/// u8s, and a false for booleans.
-#[derive(Clone, Default)]
-pub struct PeerSupports {
-   pub bep_0009: Arc<AtomicU8>,
-   pub bep_0010: Arc<AtomicBool>,
+/// When initialized with new, every field is initialized as unsupported: a 0
+/// for u8s, and a false for booleans.
+#[derive(Default)]
+pub(crate) struct PeerSupports {
+   bep_0009: u8,
+   bep_0010: bool,
 }
 
 impl PeerSupports {
-   pub fn new() -> Self {
-      PeerSupports {
-         bep_0009: Arc::new(AtomicU8::new(0)),
-         bep_0010: Arc::new(AtomicBool::new(false)),
+   pub(crate) fn from_reserved(reserved: [u8; 8]) -> Self {
+      Self {
+         bep_0010: reserved[5] & 0x10 != 0,
+         ..Self::default()
       }
    }
 }
 
-#[allow(dead_code)]
-impl Peer {
+use super::PeerActor;
+
+impl PeerActor {
+   pub(crate) fn bep_0009_id(&self) -> u8 {
+      self.supports.bep_0009
+   }
+
+   pub(crate) fn set_bep_0009(&mut self, id: u8) {
+      self.supports.bep_0009 = id;
+   }
+
+   #[allow(dead_code)]
    pub(crate) fn supports_bep_0009(&self) -> bool {
       self.bep_0009_id() > 0
    }
 
-   pub(crate) fn bep_0009_id(&self) -> u8 {
-      self.peer_supports.bep_0009.load(Ordering::Acquire)
-   }
-
+   #[allow(dead_code)]
    pub(crate) fn supports_bep_0010(&self) -> bool {
-      self.peer_supports.bep_0010.load(Ordering::Acquire)
-   }
-
-   pub(crate) fn set_bep_0009(&mut self, id: u8) {
-      self.peer_supports.bep_0009.store(id, Ordering::Release);
-   }
-
-   pub(crate) fn set_bep_0010(&mut self, status: bool) {
-      self.peer_supports.bep_0010.store(status, Ordering::Release);
-   }
-
-   /// Determines and updates what BEPs a given peer supports based off of the
-   /// reserved bytes from the peers handshake.
-   ///
-   /// This function does not inherently have to be async due to the extremely
-   /// light workload it takes on, but there's no reason for it not to be.
-   pub(crate) async fn determine_supported(&mut self) {
-      if self.reserved[5] == 0x10 {
-         self.set_bep_0010(true);
-      }
+      self.supports.bep_0010
    }
 }

--- a/crates/libtortillas/src/torrent/actor.rs
+++ b/crates/libtortillas/src/torrent/actor.rs
@@ -1008,8 +1008,8 @@ mod tests {
          Self { address, task }
       }
 
-      fn peer(&self) -> crate::peer::Peer {
-         crate::peer::Peer::from_socket_addr(self.address)
+      fn peer(&self) -> crate::peer::WirePeer {
+         crate::peer::WirePeer::from_socket_addr(self.address)
       }
    }
 

--- a/crates/libtortillas/src/torrent/messages.rs
+++ b/crates/libtortillas/src/torrent/messages.rs
@@ -21,7 +21,7 @@ use crate::{
    errors::TorrentError,
    hashes::InfoHash,
    metainfo::Info,
-   peer::{Peer, PeerId, commands::HaveInfoDict},
+   peer::{PeerId, WirePeer, commands::HaveInfoDict},
    pieces::{PieceManager, PieceScheduler},
    protocol::stream::PeerStream,
    tracker::Tracker,
@@ -38,7 +38,7 @@ pub(crate) mod events {
       /// A message from an announce actor containing new peers.
       #[message(derive(Debug))]
       #[instrument(skip(self, peers, from), fields(torrent_id = %self.info_hash(), announce_from = from.kind()))]
-      pub(crate) fn announce(&mut self, peers: Vec<Peer>, from: AnnounceFrom) {
+      pub(crate) fn announce(&mut self, peers: Vec<WirePeer>, from: AnnounceFrom) {
          trace!(peer_count = peers.len(), "Received announce message");
          for peer in peers {
             self.append_peer(peer, None);
@@ -52,8 +52,10 @@ pub(crate) mod events {
       /// not the responsibility of the engine.
       #[message]
       #[instrument(skip(self, stream), fields(torrent_id = %self.info_hash()))]
-      pub(crate) fn incoming_peer(&mut self, peer: Peer, stream: PeerStream) {
-         self.append_peer(peer, Some(stream));
+      pub(crate) fn incoming_peer(
+         &mut self, peer: WirePeer, reserved: [u8; 8], stream: PeerStream,
+      ) {
+         self.append_peer(peer, Some((stream, reserved)));
       }
 
       /// Used to manually add a peer. This is primarily used for testing but
@@ -61,15 +63,17 @@ pub(crate) mod events {
       /// come from an announce.
       #[message(derive(Debug))]
       #[instrument(skip(self), fields(torrent_id = %self.info_hash()))]
-      pub(crate) fn add_peer(&mut self, peer: Peer) {
+      pub(crate) fn add_peer(&mut self, peer: WirePeer) {
          self.append_peer(peer, None);
       }
 
       /// Sent by a connection task after peer handshaking completes.
       #[message]
       #[instrument(skip(self, stream), fields(torrent_id = %self.info_hash()))]
-      pub(crate) fn peer_connected(&mut self, peer: Peer, stream: PeerStream) {
-         self.insert_peer(peer, stream);
+      pub(crate) fn peer_connected(
+         &mut self, peer: WirePeer, reserved: [u8; 8], stream: PeerStream,
+      ) {
+         self.insert_peer(peer, reserved, stream);
       }
 
       /// Index, offset, and data for a received peer `Piece` message.

--- a/crates/libtortillas/src/torrent/swarm.rs
+++ b/crates/libtortillas/src/torrent/swarm.rs
@@ -10,7 +10,7 @@ use super::TorrentActor;
 #[cfg(feature = "live")]
 use crate::live::{PeerIdentity, PeerView};
 use crate::{
-   peer::{Peer, PeerActor, PeerActorArgs, PeerId},
+   peer::{PeerActor, PeerActorArgs, PeerId, WirePeer},
    protocol::{
       messages::{Handshake, PeerMessages},
       stream::{PeerSend, PeerStream, validate_handshake},
@@ -21,7 +21,7 @@ use crate::{
 
 impl TorrentActor {
    #[instrument(skip(self, peer, stream), fields(%self, peer_addr = ?peer.socket_addr(), torrent_id = %self.info_hash()))]
-   pub(super) fn append_peer(&self, mut peer: Peer, stream: Option<PeerStream>) {
+   pub(super) fn append_peer(&self, mut peer: WirePeer, stream: Option<(PeerStream, [u8; 8])>) {
       let info_hash = self.info_hash();
       let actor_ref = self.actor_ref.clone();
       let our_id = self.id;
@@ -29,14 +29,14 @@ impl TorrentActor {
 
       tokio::spawn(async move {
          let mut id = peer.id;
-         let stream = match stream {
-            Some(mut stream) => {
+         let (stream, reserved) = match stream {
+            Some((mut stream, reserved)) => {
                let handshake = Handshake::new(info_hash, our_id);
                if let Err(err) = stream.send(PeerMessages::Handshake(handshake)).await {
                   debug!(error = %err, peer_addr = %peer.socket_addr(), "Failed to send handshake to peer");
                   return;
                }
-               stream
+               (stream, reserved)
             }
             None => {
                let stream = PeerStream::connect(peer.socket_addr(), Some(utp_server)).await;
@@ -51,9 +51,7 @@ impl TorrentActor {
                               return;
                            }
                            id = Some(handshake.peer_id);
-                           peer.reserved = handshake.reserved;
-                           peer.determine_supported().await;
-                           stream
+                           (stream, handshake.reserved)
                         }
                         Err(err) => {
                            trace!(error = %err, peer_addr = %peer.socket_addr(), "Failed to receive handshake from peer; exiting");
@@ -84,13 +82,20 @@ impl TorrentActor {
 
          peer.id = Some(id);
 
-         if let Err(err) = actor_ref.tell(PeerConnected { peer, stream }).await {
+         if let Err(err) = actor_ref
+            .tell(PeerConnected {
+               peer,
+               reserved,
+               stream,
+            })
+            .await
+         {
             warn!(?err, peer_id = %id, "Failed to route connected peer back to torrent actor");
          }
       });
    }
 
-   pub(super) fn insert_peer(&mut self, peer: Peer, stream: PeerStream) {
+   pub(super) fn insert_peer(&mut self, peer: WirePeer, reserved: [u8; 8], stream: PeerStream) {
       let Some(id) = peer.id else {
          trace!(peer_addr = %peer.socket_addr(), "Connected peer missing peer id; ignoring");
          return;
@@ -110,13 +115,14 @@ impl TorrentActor {
             torrent: info_hash,
             peer: id,
          },
-         PeerView::from_peer(&peer, true),
+         PeerView::connected(peer.socket_addr(), id),
       ) else {
          return;
       };
 
       let peer_args = PeerActorArgs {
          peer,
+         reserved,
          stream,
          supervisor: actor_ref,
          info_hash,

--- a/crates/libtortillas/src/tracker/http.rs
+++ b/crates/libtortillas/src/tracker/http.rs
@@ -24,7 +24,7 @@ use tracing::{debug, error, instrument, trace, warn};
 use crate::{
    errors::TrackerActorError,
    hashes::InfoHash,
-   peer::{Peer, PeerId},
+   peer::{PeerId, WirePeer},
    settings::TrackerSettings,
    tracker::{Event, TrackerBase, TrackerStats, TrackerUpdate},
 };
@@ -37,7 +37,7 @@ pub struct TrackerResponse {
    pub interval: Option<usize>,
    #[serde(default)]
    #[serde(deserialize_with = "deserialize_peers")]
-   pub peers: Vec<Peer>,
+   pub peers: Vec<WirePeer>,
 }
 
 /// Tracker request. See <https://www.bittorrent.org/beps/bep_0003.html> @ trackers
@@ -221,7 +221,7 @@ impl TrackerBase for HttpTracker {
         peer_id = %self.peer_id,
         torrent_id = %self.info_hash,
     ))]
-   async fn announce(&self) -> Result<Vec<Peer>> {
+   async fn announce(&self) -> Result<Vec<WirePeer>> {
       // Update statistics
       self.stats.increment_announce_attempts();
 
@@ -347,7 +347,7 @@ fn parse_tracker_response(response_bytes: &[u8]) -> Result<TrackerResponse> {
 struct PeerVisitor;
 
 impl<'de> Visitor<'de> for PeerVisitor {
-   type Value = Vec<Peer>;
+   type Value = Vec<WirePeer>;
 
    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
       formatter.write_str("a byte array containing peer information")
@@ -393,7 +393,7 @@ impl<'de> Visitor<'de> for PeerVisitor {
          let ip = Ipv4Addr::new(chunk[0], chunk[1], chunk[2], chunk[3]);
          let port = u16::from_be_bytes([chunk[4], chunk[5]]);
 
-         peers.push(Peer::from_ipv4(ip, port));
+         peers.push(WirePeer::from_ipv4(ip, port));
       }
 
       trace!(
@@ -427,7 +427,7 @@ impl<'de> Visitor<'de> for PeerVisitor {
             Ok(ip) => {
                let port = dictionary_peer.port;
                let id_bytes: Option<[u8; 20]> = dictionary_peer.id.and_then(|b| b.try_into().ok());
-               let mut peer = Peer::from_socket_addr(SocketAddr::from((ip, port)));
+               let mut peer = WirePeer::from_socket_addr(SocketAddr::from((ip, port)));
 
                peer.id = id_bytes.map(PeerId::from);
                peers.push(peer);
@@ -451,7 +451,7 @@ impl<'de> Visitor<'de> for PeerVisitor {
 }
 
 /// Serde related code. Reference their documentation: <https://serde.rs/impl-deserialize.html>
-fn deserialize_peers<'de, D>(deserializer: D) -> Result<Vec<Peer>, D::Error>
+fn deserialize_peers<'de, D>(deserializer: D) -> Result<Vec<WirePeer>, D::Error>
 where
    D: serde::Deserializer<'de>,
 {
@@ -472,7 +472,7 @@ mod tests {
    use crate::{
       errors::TrackerActorError,
       metainfo::MetaInfo,
-      peer::{Peer, PeerId},
+      peer::{PeerId, WirePeer},
       testing::{
          KNOPPIX_TORRENT_FILE, LocalHttpTracker, init_tracing, random_port, read_torrent_fixture,
          test_info_hash, udp_server,
@@ -557,7 +557,7 @@ mod tests {
    #[cfg(feature = "live")]
    #[tokio::test]
    async fn http_tracker_when_local_tracker_is_available_then_returns_ipv4_peer() {
-      let expected_peer = Peer::from_ipv4(Ipv4Addr::LOCALHOST, 6881);
+      let expected_peer = WirePeer::from_ipv4(Ipv4Addr::LOCALHOST, 6881);
       let local_tracker = LocalHttpTracker::start([expected_peer.clone()])
          .await
          .unwrap();
@@ -573,7 +573,7 @@ mod tests {
 
    #[tokio::test]
    async fn http_tracker_instance_when_local_tracker_is_available_then_returns_peers() {
-      let expected_peer = Peer::from_ipv4(Ipv4Addr::LOCALHOST, 51413);
+      let expected_peer = WirePeer::from_ipv4(Ipv4Addr::LOCALHOST, 51413);
       let local_tracker = LocalHttpTracker::start([expected_peer.clone()])
          .await
          .unwrap();

--- a/crates/libtortillas/src/tracker/model.rs
+++ b/crates/libtortillas/src/tracker/model.rs
@@ -16,7 +16,7 @@ use super::{
 };
 use crate::{
    hashes::InfoHash,
-   peer::{Peer, PeerId},
+   peer::{PeerId, WirePeer},
    settings::TrackerSettings,
 };
 
@@ -153,7 +153,7 @@ impl Tracker {
 #[async_trait]
 pub trait TrackerBase: Send + Sync {
    async fn initialize(&self) -> Result<()>;
-   async fn announce(&self) -> Result<Vec<Peer>>;
+   async fn announce(&self) -> Result<Vec<WirePeer>>;
    async fn update(&self, update: TrackerUpdate) -> Result<()>;
    fn stats(&self) -> TrackerStats;
    fn interval(&self) -> usize;
@@ -176,7 +176,7 @@ impl TrackerBase for TrackerInstance {
       }
    }
 
-   async fn announce(&self) -> Result<Vec<Peer>> {
+   async fn announce(&self) -> Result<Vec<WirePeer>> {
       match self {
          TrackerInstance::Udp(tracker) => tracker.announce().await,
          TrackerInstance::Http(tracker) => tracker.announce().await,

--- a/crates/libtortillas/src/tracker/udp.rs
+++ b/crates/libtortillas/src/tracker/udp.rs
@@ -25,7 +25,7 @@ use tracing::{debug, error, info, instrument, trace, warn};
 use crate::{
    errors::TrackerActorError,
    hashes::InfoHash,
-   peer::{Peer, PeerId},
+   peer::{PeerId, WirePeer},
    settings::TrackerSettings,
    tracker::{Event, TrackerBase, TrackerStats, TrackerUpdate},
 };
@@ -179,8 +179,8 @@ enum TrackerResponse {
       leechers: u32,
       /// Number of seeders (4 bytes)
       seeders: u32,
-      /// List of [peers](Peer) (6 bytes per peer) unless ipv6
-      peers: Vec<Peer>,
+      /// List of [peers](WirePeer) (6 bytes per peer) unless ipv6
+      peers: Vec<WirePeer>,
    },
 
    /// Error response (8 + message length bytes total)
@@ -276,7 +276,7 @@ impl TrackerResponse {
                let ip = Ipv4Addr::from(buf.get_u32());
                let port = buf.get_u16();
 
-               peers.push(Peer::from_ipv4(ip, port));
+               peers.push(WirePeer::from_ipv4(ip, port));
             }
 
             Ok(TrackerResponse::Announce {
@@ -876,7 +876,7 @@ impl TrackerBase for UdpTracker {
         torrent_id = %self.info_hash,
         tracker_ready_state = ?self.get_ready_state(),
     ))]
-   async fn announce(&self) -> anyhow::Result<Vec<Peer>> {
+   async fn announce(&self) -> anyhow::Result<Vec<WirePeer>> {
       ensure!(
          self.get_ready_state() == ReadyState::Ready,
          "Tracker not ready for announce request"

--- a/crates/libtortillas/tests/peer_models.rs
+++ b/crates/libtortillas/tests/peer_models.rs
@@ -1,0 +1,52 @@
+use std::{
+   collections::HashSet,
+   net::{IpAddr, Ipv4Addr, SocketAddr},
+};
+
+use libtortillas::peer::{PeerId, WirePeer};
+
+#[test]
+fn wire_peer_contains_discovery_identity() {
+   let address = SocketAddr::from((Ipv4Addr::LOCALHOST, 6881));
+   let mut peer = WirePeer::from_socket_addr(address);
+
+   assert_eq!(peer.ip, IpAddr::V4(Ipv4Addr::LOCALHOST));
+   assert_eq!(peer.port, 6881);
+   assert_eq!(peer.socket_addr(), address);
+   assert!(peer.id.is_none());
+
+   peer.id = Some(PeerId::Unknown([1; 20]));
+   assert_eq!(peer.id, Some(PeerId::Unknown([1; 20])));
+}
+
+#[test]
+fn wire_peer_identity_is_keyed_by_address() {
+   let mut first = WirePeer::from_ipv4(Ipv4Addr::LOCALHOST, 6881);
+   first.id = Some(PeerId::Unknown([1; 20]));
+   let mut second = first.clone();
+   second.id = Some(PeerId::Unknown([2; 20]));
+
+   let peers = HashSet::from([first, second]);
+
+   assert_eq!(peers.len(), 1);
+}
+
+#[cfg(feature = "live")]
+#[test]
+fn frontend_peer_view_contains_observable_state() {
+   use libtortillas::{live::PeerView, metrics::PeerMetrics};
+
+   let peer = PeerView {
+      address: Some(SocketAddr::from((Ipv4Addr::LOCALHOST, 6881))),
+      client: Some("Transmission".to_string()),
+      connected: true,
+      metrics: PeerMetrics {
+         available_pieces: 4,
+         ..PeerMetrics::default()
+      },
+   };
+
+   assert!(peer.connected);
+   assert_eq!(peer.client.as_deref(), Some("Transmission"));
+   assert_eq!(peer.metrics.available_pieces, 4);
+}


### PR DESCRIPTION
## Summary

- replace the overloaded wire-level `Peer` with a minimal `WirePeer` containing only its address and optional peer ID
- move bitfield, protocol support, metadata assembly, connection state, transfer accounting, and runtime behavior into `PeerActor`
- keep `PeerView` as the consistent frontend live projection across handles, listeners, events, and facade exports
- remove obsolete peer helpers and cover the wire/frontend model boundary

## API boundary

Tracker, DHT, engine, and swarm plumbing now exchange `WirePeer`. Connected operational state is actor-owned. Frontend consumers continue to receive `PeerView` from the live API.

## Validation

- [x] `cargo nextest run --nocapture --no-fail-fast` — 192 passed, 9 skipped
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps --document-private-items`
- [x] `cargo check -p libtortillas --no-default-features`